### PR TITLE
bugfix: doesn't return the expected url but just the first

### DIFF
--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -42,7 +42,7 @@ class Sitemap
     public function getUrl(string $url)
     {
         return collect($this->tags)->first(function (Tag $tag) use ($url) {
-            return $tag->getType() === 'url' && $tag->url;
+            return $tag->getType() === 'url' && $tag->url === $url;
         });
     }
 

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -108,7 +108,7 @@ class SitemapTest extends TestCase
     public function it_returns_null_when_getting_a_non_existing_url()
     {
         $this->assertNull($this->sitemap->getUrl('/page1'));
-        
+
         $this->sitemap->add('/page1');
 
         $this->assertNull($this->sitemap->getUrl('/page2'));

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -89,24 +89,28 @@ class SitemapTest extends TestCase
             ->add('/page2')
             ->add('/page3');
 
-        $this->assertTrue($this->sitemap->hasUrl('/page1'));
-        $this->assertTrue($this->sitemap->hasUrl('/page4'));
+        $this->assertTrue($this->sitemap->hasUrl('/page2'));
     }
 
     /** @test */
     public function it_can_get_a_specific_url()
     {
         $this->sitemap->add('/page1');
+        $this->sitemap->add('/page2');
 
-        $url = $this->sitemap->getUrl('/page1');
+        $url = $this->sitemap->getUrl('/page2');
 
         $this->assertInstanceOf(Url::class, $url);
-        $this->assertSame('/page1', $url->url);
+        $this->assertSame('/page2', $url->url);
     }
 
     /** @test */
     public function it_returns_null_when_getting_a_non_existing_url()
     {
         $this->assertNull($this->sitemap->getUrl('/page1'));
+        
+        $this->sitemap->add('/page1');
+
+        $this->assertNull($this->sitemap->getUrl('/page2'));
     }
 }


### PR DESCRIPTION
I found a bug in `Sitemap\Sitemap` class that did not allow to obtain the expected url with the `getUrl` method.
If there were some elements in the array (the `tags` property), the method always returned the first element.
Only if the array was empty `getUrl` returned `null`.