### PR TITLE
#50: add the ability to create sitemap index

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,43 @@ Sitemap::create()
    ->writeToFile($sitemapPath);
 ```
 
+### Creating a sitemap index
+You can even create a sitemap index:
+```php
+use Spatie\Sitemap\SitemapIndex;
+
+SitemapIndex::create()
+    ->add('/pages_sitemap.xml')
+    ->add('/posts_sitemap.xml')
+    ->writeToFile($sitemapIndexPath);
+```
+You can pass a `Spatie\Sitemap\Tags\Sitemap` object to manually set the `lastModificationDate` property.
+```php
+use Spatie\Sitemap\SitemapIndex;
+use Spatie\Sitemap\Tags\Sitemap;
+
+SitemapIndex::create()
+    ->add('/pages_sitemap.xml')
+    ->add(Sitemap::create('/posts_sitemap.xml')
+        ->setLastModificationDate(Carbon::yesterday()))
+    ->writeToFile($sitemapIndexPath);
+```
+the generated sitemap index will look similar to this:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+   <sitemap>
+      <loc>http://www.example.com/pages_sitemap.xml</loc>
+      <lastmod>2016-01-01T00:00:00+00:00</lastmod>
+   </sitemap>
+   <sitemap>
+      <loc>http://www.example.com/posts_sitemap.xml</loc>
+      <lastmod>2015-12-31T00:00:00+00:00</lastmod>
+   </sitemap>
+</sitemapindex>
+```
+
+
 ## Generating the sitemap frequently
 
 Your site will probably be updated from time to time. In order to let your sitemap reflect these changes you can run the generator periodically. The easiest way of doing this is do make use of Laravel's default scheduling capabilities.

--- a/resources/views/sitemapIndex/index.blade.php
+++ b/resources/views/sitemapIndex/index.blade.php
@@ -1,0 +1,6 @@
+<?= '<'.'?'.'xml version="1.0" encoding="UTF-8"?>'."\n" ?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    @foreach($tags as $tag)
+        @include('laravel-sitemap::sitemapIndex/' . $tag->getType())
+    @endforeach
+</sitemapindex>

--- a/resources/views/sitemapIndex/sitemap.blade.php
+++ b/resources/views/sitemapIndex/sitemap.blade.php
@@ -1,0 +1,8 @@
+<sitemap>
+    @if (! empty($tag->url))
+        <loc>{{ $tag->url }}</loc>
+    @endif
+    @if (! empty($tag->lastModificationDate))
+        <lastmod>{{ $tag->lastModificationDate->format(DateTime::ATOM) }}</lastmod>
+    @endif
+</sitemap>

--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -19,17 +19,17 @@ class Sitemap
     }
 
     /**
-     * @param string|\Spatie\Sitemap\Tags\Tag $tag
+     * @param string|\Spatie\Sitemap\Tags\Tag $url
      *
      * @return $this
      */
-    public function add($tag)
+    public function add($url)
     {
-        if (is_string($tag)) {
-            $tag = Url::create($tag);
+        if (is_string($url)) {
+            $url = Url::create($url);
         }
 
-        $this->tags[] = $tag;
+        $this->tags[] = $url;
 
         return $this;
     }

--- a/src/SitemapIndex.php
+++ b/src/SitemapIndex.php
@@ -49,7 +49,7 @@ class SitemapIndex
     }
 
     /**
-     * Check if there is the provided sitemap in the index
+     * Check if there is the provided sitemap in the index.
      *
      * @param string $url
      *
@@ -61,7 +61,7 @@ class SitemapIndex
     }
 
     /**
-     * Get the inflated template content
+     * Get the inflated template content.
      *
      * @return string
      */

--- a/src/SitemapIndex.php
+++ b/src/SitemapIndex.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Spatie\Sitemap;
+
+use Spatie\Sitemap\Tags\Tag;
+use Spatie\Sitemap\Tags\Sitemap;
+
+class SitemapIndex
+{
+    /** @var array */
+    protected $tags = [];
+
+    /**
+     * @return static
+     */
+    public static function create()
+    {
+        return new static();
+    }
+
+    /**
+     * @param string|\Spatie\Sitemap\Tags\Tag $tag
+     *
+     * @return $this
+     */
+    public function add($tag)
+    {
+        if (is_string($tag)) {
+            $tag = Sitemap::create($tag);
+        }
+
+        $this->tags[] = $tag;
+
+        return $this;
+    }
+
+    /**
+     * Get sitemap tag.
+     * 
+     * @param string $url
+     *
+     * @return \Spatie\Sitemap\Tags\Sitemap|null
+     */
+    public function getSitemap(string $url)
+    {
+        return collect($this->tags)->first(function (Tag $tag) use ($url) {
+            return $tag->getType() === 'sitemap' && $tag->url === $url;
+        });
+    }
+
+    /**
+     * Check if there is the provided sitemap in the index
+     * 
+     * @param string $url
+     * 
+     * @return bool
+     */
+    public function hasSitemap(string $url): bool
+    {
+        return (bool) $this->getSitemap($url);
+    }
+
+    /**
+     * Get the inflated template content
+     * 
+     * @return string
+     */
+    public function render(): string
+    {
+        $tags = $this->tags;
+
+        return view('laravel-sitemap::sitemapIndex/index')
+            ->with(compact('tags'))
+            ->render();
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return $this
+     */
+    public function writeToFile(string $path)
+    {
+        file_put_contents($path, $this->render());
+
+        return $this;
+    }
+}

--- a/src/SitemapIndex.php
+++ b/src/SitemapIndex.php
@@ -36,7 +36,7 @@ class SitemapIndex
 
     /**
      * Get sitemap tag.
-     * 
+     *
      * @param string $url
      *
      * @return \Spatie\Sitemap\Tags\Sitemap|null
@@ -50,9 +50,9 @@ class SitemapIndex
 
     /**
      * Check if there is the provided sitemap in the index
-     * 
+     *
      * @param string $url
-     * 
+     *
      * @return bool
      */
     public function hasSitemap(string $url): bool
@@ -62,7 +62,7 @@ class SitemapIndex
 
     /**
      * Get the inflated template content
-     * 
+     *
      * @return string
      */
     public function render(): string

--- a/src/Tags/Sitemap.php
+++ b/src/Tags/Sitemap.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Spatie\Sitemap\Tags;
+
+use DateTime;
+use Carbon\Carbon;
+
+class Sitemap extends Tag
+{
+    /** @var string */
+    public $url = '';
+
+    /** @var \Carbon\Carbon */
+    public $lastModificationDate;
+
+    public static function create(string $url): Sitemap
+    {
+        return new static($url);
+    }
+
+    public function __construct(string $url)
+    {
+        $this->url = $url;
+
+        $this->lastModificationDate = Carbon::now();
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return $this
+     */
+    public function setUrl(string $url = '')
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * @param \DateTime $lastModificationDate
+     *
+     * @return $this
+     */
+    public function setLastModificationDate(DateTime $lastModificationDate)
+    {
+        $this->lastModificationDate = $lastModificationDate;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function path(): string
+    {
+        return parse_url($this->url)['path'] ?? '';
+    }
+
+    /**
+     * @param int|null $index
+     *
+     * @return array|null|string
+     */
+    public function segments(int $index = null)
+    {
+        $segments = collect(explode('/', $this->path()))
+            ->filter(function ($value) {
+                return $value !== '';
+            })
+            ->values()
+            ->toArray();
+
+        if (! is_null($index)) {
+            return $this->segment($index);
+        }
+
+        return $segments;
+    }
+
+    /**
+     * @param int $index
+     *
+     * @return string|null
+     */
+    public function segment(int $index)
+    {
+        return $this->segments()[$index - 1] ?? null;
+    }
+}

--- a/src/Tags/Sitemap.php
+++ b/src/Tags/Sitemap.php
@@ -56,35 +56,4 @@ class Sitemap extends Tag
     {
         return parse_url($this->url)['path'] ?? '';
     }
-
-    /**
-     * @param int|null $index
-     *
-     * @return array|null|string
-     */
-    public function segments(int $index = null)
-    {
-        $segments = collect(explode('/', $this->path()))
-            ->filter(function ($value) {
-                return $value !== '';
-            })
-            ->values()
-            ->toArray();
-
-        if (! is_null($index)) {
-            return $this->segment($index);
-        }
-
-        return $segments;
-    }
-
-    /**
-     * @param int $index
-     *
-     * @return string|null
-     */
-    public function segment(int $index)
-    {
-        return $this->segments()[$index - 1] ?? null;
-    }
 }

--- a/tests/SitemapIndexTest.php
+++ b/tests/SitemapIndexTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Spatie\Sitemap\Test;
+
+use Spatie\Sitemap\SitemapIndex;
+use Spatie\Sitemap\Tags\Sitemap;
+
+class SitemapIndexTest extends TestCase
+{
+    /** @var \Spatie\Sitemap\SitemapIndex */
+    protected $index;
+
+    /** @test */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->index = new SitemapIndex();
+    }
+
+    /** @test */
+    public function it_provides_a_create_method()
+    {
+        $index = SitemapIndex::create();
+
+        $this->assertInstanceOf(SitemapIndex::class, $index);
+    }
+
+    /** @test */
+    public function it_can_render_an_empty_index()
+    {
+        $this->assertIsEqualToContentsOfStub('emptyIndex', $this->index->render());
+    }
+
+    /** @test */
+    public function it_can_write_an_index_to_a_file()
+    {
+        $path = $this->getTempDirectory('test.xml');
+
+        $this->index->writeToFile($path);
+
+        $this->assertIsEqualToContentsOfStub('emptyIndex', file_get_contents($path));
+    }
+
+    /** @test */
+    public function an_url_string_can_be_added_to_the_index()
+    {
+        $this->index->add('/sitemap1.xml');
+
+        $this->assertIsEqualToContentsOfStub('singleSitemap', $this->index->render());
+    }
+
+    /** @test */
+    public function a_sitemap_object_can_be_added_to_the_index()
+    {
+        $this->index->add(Sitemap::create('/sitemap1.xml'));
+
+        $this->assertIsEqualToContentsOfStub('singleSitemap', $this->index->render());
+    }
+
+    /** @test */
+    public function multiple_sitemaps_can_be_added_to_the_index()
+    {
+        $this->index
+            ->add(Sitemap::create('/sitemap1.xml'))
+            ->add(Sitemap::create('/sitemap2.xml'));
+
+        $this->assertIsEqualToContentsOfStub('multipleSitemaps', $this->index->render());
+    }
+
+    /** @test */
+    public function it_can_render_a_sitemaps_with_all_its_set_properties()
+    {
+        $this->index
+            ->add(Sitemap::create('/sitemap1.xml')
+                ->setLastModificationDate($this->now->subDay())
+            );
+
+        $this->assertIsEqualToContentsOfStub('customSitemap', $this->index->render());
+    }
+
+    /** @test */
+    public function it_can_determine_if_it_contains_a_given_sitemap()
+    {
+        $this->index
+            ->add('/sitemap1.xml')
+            ->add('/sitemap2.xml')
+            ->add('/sitemap3.xml');
+
+        $this->assertTrue($this->index->hasSitemap('/sitemap2.xml'));
+    }
+
+    /** @test */
+    public function it_can_get_a_specific_sitemap()
+    {
+        $this->index->add('/sitemap1.xml');
+        $this->index->add('/sitemap2.xml');
+
+        $sitemap = $this->index->getSitemap('/sitemap2.xml');
+
+        $this->assertInstanceOf(Sitemap::class, $sitemap);
+        $this->assertSame('/sitemap2.xml', $sitemap->url);
+    }
+
+    /** @test */
+    public function it_returns_null_when_getting_a_non_existing_sitemap()
+    {
+        $this->assertNull($this->index->getSitemap('/sitemap1.xml'));
+
+        $this->index->add('/sitemap1.xml');
+
+        $this->assertNotNull($this->index->getSitemap('/sitemap1.xml'));
+
+        $this->assertNull($this->index->getSitemap('/sitemap2.xml'));
+    }
+}

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -34,6 +34,16 @@ class UrlTest extends TestCase
     {
         $this->assertEquals($this->now->toAtomString(), $this->url->lastModificationDate->toAtomString());
     }
+    
+    /** @test */
+    public function url_can_be_set()
+    {
+        $url = Url::create('defaultUrl');
+
+        $url->setUrl('testUrl');
+        
+        $this->assertEquals('testUrl', $url->url);
+    }
 
     /** @test */
     public function last_modification_date_can_be_set()

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -34,14 +34,14 @@ class UrlTest extends TestCase
     {
         $this->assertEquals($this->now->toAtomString(), $this->url->lastModificationDate->toAtomString());
     }
-    
+
     /** @test */
     public function url_can_be_set()
     {
         $url = Url::create('defaultUrl');
 
         $url->setUrl('testUrl');
-        
+
         $this->assertEquals('testUrl', $url->url);
     }
 

--- a/tests/sitemapStubs/customSitemap.xml
+++ b/tests/sitemapStubs/customSitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <sitemap>
+        <loc>/sitemap1.xml</loc>
+        <lastmod>2015-12-31T00:00:00+00:00</lastmod>
+    </sitemap>
+</sitemapindex>

--- a/tests/sitemapStubs/empty.xml
+++ b/tests/sitemapStubs/empty.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 </urlset>

--- a/tests/sitemapStubs/emptyIndex.xml
+++ b/tests/sitemapStubs/emptyIndex.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+</sitemapindex>

--- a/tests/sitemapStubs/multipleSitemaps.xml
+++ b/tests/sitemapStubs/multipleSitemaps.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <sitemap>
+        <loc>/sitemap1.xml</loc>
+        <lastmod>2016-01-01T00:00:00+00:00</lastmod>
+    </sitemap>
+    <sitemap>
+        <loc>/sitemap2.xml</loc>
+        <lastmod>2016-01-01T00:00:00+00:00</lastmod>
+    </sitemap>
+</sitemapindex>

--- a/tests/sitemapStubs/singleSitemap.xml
+++ b/tests/sitemapStubs/singleSitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <sitemap>
+        <loc>/sitemap1.xml</loc>
+        <lastmod>2016-01-01T00:00:00+00:00</lastmod>
+    </sitemap>
+</sitemapindex>


### PR DESCRIPTION
#50: add SitemapIndex class to create sitemap index by passing urls of already created sitemaps.
Extra: add test for Sitemap\Tags\Url `setUrl `method, now code coverage is 100%