### PR TITLE
Remember to register the command in the commands array in Kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,14 @@ That command should then be scheduled in the console kernel.
 
 ```php
 // app/Console/Kernel.php
+
+protected $commands = [
+        'App\Console\Commands\GenerateSitemap'
+];
+
 protected function schedule(Schedule $schedule)
 {
+   
     ...
     $schedule->command('sitemap:generate')->daily();
     ...


### PR DESCRIPTION
A simple update of the README file to remind the users to register the command in the $commands array