### PR TITLE
Allow Laravel5.5 usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "~5.3.0|~5.4.0",
+        "illuminate/support": "~5.3.0|~5.4.0|~5.5.0",
         "nesbot/carbon": "^1.21",
         "spatie/crawler": "^2.0.2",
         "spatie/phpunit-snapshot-assertions": "^0.4.1",


### PR DESCRIPTION
Laravel 5.5 isn't released yet, but lots of people (including me) are already using it. This pull request enables the usage of this package in Laravel 5.5

Also, don't forget to tag a new release after merging!

:octocat: 