### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "~5.3.0|~5.4.0|~5.5.x-dev",
+        "illuminate/support": "~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
         "nesbot/carbon": "^1.21",
         "spatie/crawler": "^2.0.2",
         "spatie/phpunit-snapshot-assertions": "^0.4.1",
         "spatie/temporary-directory": "^1.1"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev",
+        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev|~3.5.x-dev",
         "phpunit/phpunit": "^6.2"
     },
     "autoload": {
@@ -51,3 +51,4 @@
         }
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "~5.3.0|~5.4.0",
+        "illuminate/support": "~5.3.0|~5.4.0|~5.5.x-dev",
         "nesbot/carbon": "^1.21",
         "spatie/crawler": "^2.0.2",
         "spatie/phpunit-snapshot-assertions": "^0.4.1",
         "spatie/temporary-directory": "^1.1"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.3.0|~3.4.0",
-        "phpunit/phpunit": "^5.7"
+        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev",
+        "phpunit/phpunit": "^6.2"
     },
     "autoload": {
         "psr-4": {
@@ -42,7 +42,7 @@
     },
     "config": {
         "sort-packages": true
-  },
+    },
     "extra": {
         "laravel": {
             "providers": [


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-sitemap/phpunit.xml.dist

SSSS..............................                                34 / 34 (100%)

Time: 3.47 seconds, Memory: 12.00MB

There were 4 skipped tests:

1) Spatie\Sitemap\Test\SitemapGeneratorTest::it_can_generate_a_sitemap
The testserver is not running.

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-sitemap/tests/SitemapGeneratorTest.php:89
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-sitemap/tests/SitemapGeneratorTest.php:17

2) Spatie\Sitemap\Test\SitemapGeneratorTest::it_can_modify_the_attributes_while_generating_the_sitemap
The testserver is not running.

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-sitemap/tests/SitemapGeneratorTest.php:89
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-sitemap/tests/SitemapGeneratorTest.php:17

3) Spatie\Sitemap\Test\SitemapGeneratorTest::it_will_not_add_the_url_to_the_site_map_if_has_crawled_does_not_return_it
The testserver is not running.

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-sitemap/tests/SitemapGeneratorTest.php:89
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-sitemap/tests/SitemapGeneratorTest.php:17

4) Spatie\Sitemap\Test\SitemapGeneratorTest::it_will_not_crawl_an_url_if_should_crawl_returns_false
The testserver is not running.

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-sitemap/tests/SitemapGeneratorTest.php:89
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-sitemap/tests/SitemapGeneratorTest.php:17

OK, but incomplete, skipped, or risky tests!
Tests: 34, Assertions: 38, Skipped: 4.

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments