### PR TITLE
Removed unused parameter which was void anyway

### DIFF
--- a/tests/SitemapGeneratorTest.php
+++ b/tests/SitemapGeneratorTest.php
@@ -17,8 +17,6 @@ class SitemapGeneratorTest extends TestCase
         $this->skipIfTestServerIsNotRunning();
 
         parent::setUp();
-
-        $this->sitemapGenerator = SitemapGenerator::create('http://localhost:4020')->setConcurrency(1);
     }
 
     /** @test */


### PR DESCRIPTION
The parameter 'sitemapGenerator' is never being used in this test.
Also 'setConcurrency()' returns void, so it was never initialized.