### PR TITLE
Duplicate entries should not be permitted.

### DIFF
--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -29,7 +29,9 @@ class Sitemap
             $tag = Url::create($tag);
         }
 
-        $this->tags[] = $tag;
+        if (!in_array($tag, $this->tags)) {
+            $this->tags[] = $tag;
+        }
 
         return $this;
     }

--- a/tests/CustomCrawlProfile.php
+++ b/tests/CustomCrawlProfile.php
@@ -11,7 +11,6 @@ class CustomCrawlProfile implements CrawlProfile
      * Determine if the given url should be crawled.
      *
      * @param \Spatie\Crawler\Url $url
-     *
      * @return bool
      */
     public function shouldCrawl(Url $url): bool

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -50,6 +50,15 @@ class SitemapTest extends TestCase
     }
 
     /** @test */
+    public function a_url_string_can_not_be_added_twice_to_the_sitemap()
+    {
+        $this->sitemap->add('/home');
+        $this->sitemap->add('/home');
+
+        $this->assertMatchesXmlSnapshot($this->sitemap->render());
+    }
+
+    /** @test */
     public function an_url_with_an_alternate_can_be_added_to_the_sitemap()
     {
         $url = Url::create('/home')

--- a/tests/__snapshots__/SitemapTest__a_url_string_can_not_be_added_twice_to_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapTest__a_url_string_can_not_be_added_twice_to_the_sitemap__1.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>/home</loc>
+    <lastmod>2016-01-01T00:00:00+00:00</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
When a project is crawled and a sitemap is generated, steps are taken to ensure that a given page is not entered into the sitemap more than once. However, if a developer should choose to first crawl a site, then custom add URLs the possibility exists that the added URLs will be duplicate. To prevent this I have added a simple check of the listed URLs prior to adding the new URL to the sitemap.