### PR TITLE
More fix to prevent duplicates

### DIFF
--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -29,9 +29,27 @@ class Sitemap
             $tag = Url::create($tag);
         }
 
-        if (! in_array($tag, $this->tags)) {
+        if (! $this->hasUrl($tag->url)) {
             $this->tags[] = $tag;
+        } else {
+            $oldTag = $this->getUrl($tag->url);
+            if ($tag->isNewer($oldTag)) {
+                $this->update($oldTag, $tag);
+            }
         }
+
+        return $this;
+    }
+
+    /**
+     * @param Url $oldTag
+     * @param Url $newTag
+     *
+     * @return $this
+     */
+    public function update(Url $oldTag, Url $newTag)
+    {
+        array_splice($this->tags, array_search($oldTag, $this->tags), 1, [$newTag]);
 
         return $this;
     }

--- a/src/Tags/Url.php
+++ b/src/Tags/Url.php
@@ -144,4 +144,24 @@ class Url extends Tag
     {
         return $this->segments()[$index - 1] ?? null;
     }
+
+    /**
+     * @param Url $compare
+     *
+     * @return Url
+     */
+    public function max(Url $compare)
+    {
+        return $this->lastModificationDate->gt($compare->lastModificationDate) ? $this : $compare;
+    }
+
+    /**
+     * @param Url $compare
+     *
+     * @return bool
+     */
+    public function isNewer(Url $compare)
+    {
+        return $this->max($compare) === $this;
+    }
 }

--- a/src/Tags/Url.php
+++ b/src/Tags/Url.php
@@ -150,7 +150,7 @@ class Url extends Tag
      *
      * @return Url
      */
-    public function max(Url $compare)
+    public function max(self $compare)
     {
         return $this->lastModificationDate->gt($compare->lastModificationDate) ? $this : $compare;
     }
@@ -160,7 +160,7 @@ class Url extends Tag
      *
      * @return bool
      */
-    public function isNewer(Url $compare)
+    public function isNewer(self $compare)
     {
         return $this->max($compare) === $this;
     }

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Sitemap\Test;
 
+use Carbon\Carbon;
 use Spatie\Sitemap\Sitemap;
 use Spatie\Sitemap\Tags\Url;
 
@@ -84,6 +85,36 @@ class SitemapTest extends TestCase
         $this->sitemap
             ->add(Url::create('/home'))
             ->add(Url::create('/contact'));
+
+        $this->assertMatchesXmlSnapshot($this->sitemap->render());
+    }
+
+    /** @test */
+    public function newer_urls_will_be_replaced_and_not_added_anew()
+    {
+        $old = Url::create('http://example.com')
+            ->setLastModificationDate(Carbon::create(2018, 1, 01));
+        $new = Url::create('http://example.com')
+            ->setLastModificationDate(Carbon::create(2018, 1, 11));
+
+        $this->sitemap
+            ->add($old)
+            ->add($new);
+
+        $this->assertMatchesXmlSnapshot($this->sitemap->render());
+    }
+
+    /** @test */
+    public function older_urls_will_be_rejected_and_not_added()
+    {
+        $old = Url::create('http://example.com')
+            ->setLastModificationDate(Carbon::create(2018, 1, 01));
+        $new = Url::create('http://example.com')
+            ->setLastModificationDate(Carbon::create(2018, 1, 11));
+
+        $this->sitemap
+            ->add($new)
+            ->add($old);
 
         $this->assertMatchesXmlSnapshot($this->sitemap->render());
     }

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -93,9 +93,9 @@ class SitemapTest extends TestCase
     public function newer_urls_will_be_replaced_and_not_added_anew()
     {
         $old = Url::create('http://example.com')
-            ->setLastModificationDate(Carbon::create(2018, 1, 01));
+            ->setLastModificationDate(Carbon::create(2018, 1, 01, 0, 0, 0));
         $new = Url::create('http://example.com')
-            ->setLastModificationDate(Carbon::create(2018, 1, 11));
+            ->setLastModificationDate(Carbon::create(2018, 1, 11, 0, 0, 0));
 
         $this->sitemap
             ->add($old)
@@ -108,9 +108,9 @@ class SitemapTest extends TestCase
     public function older_urls_will_be_rejected_and_not_added()
     {
         $old = Url::create('http://example.com')
-            ->setLastModificationDate(Carbon::create(2018, 1, 01));
+            ->setLastModificationDate(Carbon::create(2018, 1, 01, 0, 0, 0));
         $new = Url::create('http://example.com')
-            ->setLastModificationDate(Carbon::create(2018, 1, 11));
+            ->setLastModificationDate(Carbon::create(2018, 1, 11, 0, 0, 0));
 
         $this->sitemap
             ->add($new)

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -132,4 +132,28 @@ class UrlTest extends TestCase
     {
         $this->assertNull(Url::create('http://example.com/part1/part2/part3')->segment(5));
     }
+
+    /** @test */
+    public function it_can_determine_most_recent_modification()
+    {
+        $old = Url::create('http://example.com')
+            ->setLastModificationDate(Carbon::create(2018, 1, 01));
+        $new = Url::create('http://example.com')
+            ->setLastModificationDate(Carbon::create(2018, 1, 11));
+
+        $this->assertEquals($old->max($new), $new);
+        $this->assertEquals($new->max($old), $new);
+    }
+
+    /** @test */
+    public function it_can_decide_newer_urls()
+    {
+        $old = Url::create('http://example.com')
+            ->setLastModificationDate(Carbon::create(2018, 1, 01));
+        $new = Url::create('http://example.com')
+            ->setLastModificationDate(Carbon::create(2018, 1, 11));
+
+        $this->assertTrue($new->isNewer($old));
+        $this->assertFalse($old->isNewer($new));
+    }
 }

--- a/tests/__snapshots__/SitemapTest__newer_urls_will_be_replaced_and_not_added_anew__1.xml
+++ b/tests/__snapshots__/SitemapTest__newer_urls_will_be_replaced_and_not_added_anew__1.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>http://example.com</loc>
+    <lastmod>2018-01-11T00:00:00+00:00</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/tests/__snapshots__/SitemapTest__older_urls_will_be_rejected_and_not_added__1.xml
+++ b/tests/__snapshots__/SitemapTest__older_urls_will_be_rejected_and_not_added__1.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>http://example.com</loc>
+    <lastmod>2018-01-11T00:00:00+00:00</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
While the previous PR prevented **exact** duplicates.  I looked again and this new PR prevents duplicate entries for the **same URL**.  In this version, I am checking to see which URL contains a newer ```lastModificationDate``` and updates to it if necessary.