### PR TITLE
fix default priority and clamp it

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,13 @@ The generated sitemap will look similar to this:
         <loc>https://example.com</loc>
         <lastmod>2016-01-01T00:00:00+00:00</lastmod>
         <changefreq>daily</changefreq>
-        <priority>0.8</priority>
+        <priority>0.5</priority>
     </url>
     <url>
         <loc>https://example.com/page</loc>
         <lastmod>2016-01-01T00:00:00+00:00</lastmod>
         <changefreq>daily</changefreq>
-        <priority>0.8</priority>
+        <priority>0.5</priority>
     </url>
 
     ...

--- a/src/Tags/Url.php
+++ b/src/Tags/Url.php
@@ -25,7 +25,7 @@ class Url extends Tag
     public $changeFrequency;
 
     /** @var float */
-    public $priority = 0.8;
+    public $priority = 0.5;
 
     /** @var array */
     public $alternates = [];
@@ -87,7 +87,7 @@ class Url extends Tag
      */
     public function setPriority(float $priority)
     {
-        $this->priority = $priority;
+        $this->priority = max(0, min(1, $priority));
 
         return $this;
     }

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -56,6 +56,7 @@ class UrlTest extends TestCase
         $this->assertEquals($carbon->toAtomString(), $this->url->lastModificationDate->toAtomString());
     }
 
+    /** @test */
     public function priority_can_be_set()
     {
         $this->url->setPriority(0.1);
@@ -63,6 +64,7 @@ class UrlTest extends TestCase
         $this->assertEquals(0.1, $this->url->priority);
     }
 
+    /** @test */
     public function change_frequency_can_be_set()
     {
         $this->url->setChangeFrequency(Url::CHANGE_FREQUENCY_YEARLY);

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -65,6 +65,16 @@ class UrlTest extends TestCase
     }
 
     /** @test */
+    public function priority_is_clamped()
+    {
+        $this->url->setPriority(-0.1);
+        $this->assertEquals(0, $this->url->priority);
+
+        $this->url->setPriority(1.1);
+        $this->assertEquals(1, $this->url->priority);
+    }
+
+    /** @test */
     public function change_frequency_can_be_set()
     {
         $this->url->setChangeFrequency(Url::CHANGE_FREQUENCY_YEARLY);

--- a/tests/__snapshots__/SitemapGeneratorTest__it_can_generate_a_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapGeneratorTest__it_can_generate_a_sitemap__1.xml
@@ -4,36 +4,36 @@
     <loc>http://localhost:4020/</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page1</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page2</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page3</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page4</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page5</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapGeneratorTest__it_can_modify_the_attributes_while_generating_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapGeneratorTest__it_can_modify_the_attributes_while_generating_the_sitemap__1.xml
@@ -4,19 +4,19 @@
     <loc>http://localhost:4020/</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page1</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page2</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page3</loc>
@@ -28,12 +28,12 @@
     <loc>http://localhost:4020/page4</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page5</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapGeneratorTest__it_can_use_a_custom_profile__1.xml
+++ b/tests/__snapshots__/SitemapGeneratorTest__it_can_use_a_custom_profile__1.xml
@@ -4,6 +4,6 @@
     <loc>http://localhost:4020/</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapGeneratorTest__it_will_not_add_the_url_to_the_site_map_if_has_crawled_does_not_return_it__1.xml
+++ b/tests/__snapshots__/SitemapGeneratorTest__it_will_not_add_the_url_to_the_site_map_if_has_crawled_does_not_return_it__1.xml
@@ -4,30 +4,30 @@
     <loc>http://localhost:4020/</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page1</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page2</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page4</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page5</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapGeneratorTest__it_will_not_crawl_an_url_if_should_crawl_returns_false__1.xml
+++ b/tests/__snapshots__/SitemapGeneratorTest__it_will_not_crawl_an_url_if_should_crawl_returns_false__1.xml
@@ -4,24 +4,24 @@
     <loc>http://localhost:4020/</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page1</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page2</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page4</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__a_url_string_can_not_be_added_twice_to_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapTest__a_url_string_can_not_be_added_twice_to_the_sitemap__1.xml
@@ -4,6 +4,6 @@
     <loc>/home</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__an_url_object_can_be_added_to_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapTest__an_url_object_can_be_added_to_the_sitemap__1.xml
@@ -4,6 +4,6 @@
     <loc>/home</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__an_url_string_can_be_added_to_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapTest__an_url_string_can_be_added_to_the_sitemap__1.xml
@@ -4,6 +4,6 @@
     <loc>/home</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__an_url_with_an_alternate_can_be_added_to_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapTest__an_url_with_an_alternate_can_be_added_to_the_sitemap__1.xml
@@ -6,6 +6,6 @@
     <xhtml:link rel="alternate" hreflang="fr" href="/maison"/>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__multiple_urls_can_be_added_to_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapTest__multiple_urls_can_be_added_to_the_sitemap__1.xml
@@ -4,12 +4,12 @@
     <loc>/contact</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>/home</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <priority>0.5</priority>
   </url>
 </urlset>


### PR DESCRIPTION
The default value of `priority` is `0.5` and it should be between 0 and 1. There is also no reason to use `0.8` as default cause the priority is just handled as relative value between all entries. 
https://www.sitemaps.org/de/protocol.html#prioritydef