### PR TITLE
Update SitemapGenerator for setConcurrency and setMaximumCrawlCount usage

### DIFF
--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -83,14 +83,14 @@ class SitemapGenerator
     public function shouldCrawl(callable $shouldCrawl)
     {
         $this->shouldCrawl = $shouldCrawl;
-
+        
         return $this;
     }
 
     public function hasCrawled(callable $hasCrawled)
     {
         $this->hasCrawled = $hasCrawled;
-
+        
         return $this;
     }
 

--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -58,11 +58,15 @@ class SitemapGenerator
     public function setConcurrency(int $concurrency)
     {
         $this->concurrency = $concurrency;
+        
+        return $this;
     }
 
     public function setMaximumCrawlCount(int $maximumCrawlCount)
     {
         $this->maximumCrawlCount = $maximumCrawlCount;
+        
+        return $this;
     }
 
     public function setUrl(string $urlToBeCrawled)

--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -58,14 +58,14 @@ class SitemapGenerator
     public function setConcurrency(int $concurrency)
     {
         $this->concurrency = $concurrency;
-        
+
         return $this;
     }
 
     public function setMaximumCrawlCount(int $maximumCrawlCount)
     {
         $this->maximumCrawlCount = $maximumCrawlCount;
-        
+
         return $this;
     }
 
@@ -83,14 +83,14 @@ class SitemapGenerator
     public function shouldCrawl(callable $shouldCrawl)
     {
         $this->shouldCrawl = $shouldCrawl;
-        
+
         return $this;
     }
 
     public function hasCrawled(callable $hasCrawled)
     {
         $this->hasCrawled = $hasCrawled;
-        
+
         return $this;
     }
 


### PR DESCRIPTION
If you used the following code from the readme it doesn't work, the methods `setMaximumCrawlCount` and `setConcurrency` should return this, right?

```php
use Spatie\Sitemap\SitemapGenerator;
use Spatie\Crawler\Url;

SitemapGenerator::create('https://example.com')
    ->setMaximumCrawlCount(500) // only the 500 first pages will be crawled
    ->writeToFile(public_path('sitemap.xml'));
```