### PR TITLE
Update SitemapGenerator for setConcurrency and setMaximumCrawlCount usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,19 @@ SitemapGenerator::create('https://example.com')
     ...
 ```
 
+#### Limiting the max crawl depth
+
+By default, the crawler continues until it has crawled every page of the supplied URL. If you want to limit the depth of the crawler you can use the `setMaximumDepth` method.
+
+```php
+use Spatie\Sitemap\SitemapGenerator;
+use Spatie\Crawler\Url;
+
+SitemapGenerator::create('https://example.com')
+    ->setMaximumDepth(500)
+    ...
+```
+
 #### Executing Javascript
 
    

--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -34,6 +34,9 @@ class SitemapGenerator
     /** @var int|null */
     protected $maximumCrawlCount = null;
 
+    /** @var int|null */
+    protected $maximumDepth = null;
+
     /**
      * @param string $urlToBeCrawled
      *
@@ -58,11 +61,22 @@ class SitemapGenerator
     public function setConcurrency(int $concurrency)
     {
         $this->concurrency = $concurrency;
+
+        return $this;
     }
 
     public function setMaximumCrawlCount(int $maximumCrawlCount)
     {
         $this->maximumCrawlCount = $maximumCrawlCount;
+
+        return $this;
+    }
+
+    public function setMaximumDepth(int $maximumDepth)
+    {
+        $this->maximumDepth = $maximumDepth;
+
+        return $this;
     }
 
     public function setUrl(string $urlToBeCrawled)
@@ -98,6 +112,10 @@ class SitemapGenerator
 
         if (! is_null($this->maximumCrawlCount)) {
             $this->crawler->setMaximumCrawlCount($this->maximumCrawlCount);
+        }
+
+        if (! is_null($this->maximumDepth)) {
+            $this->crawler->setMaximumDepth($this->maximumDepth);
         }
 
         $this->crawler

--- a/tests/SitemapGeneratorTest.php
+++ b/tests/SitemapGeneratorTest.php
@@ -93,6 +93,30 @@ class SitemapGeneratorTest extends TestCase
         $this->assertMatchesXmlSnapshot(file_get_contents($sitemapPath));
     }
 
+    /** @test */
+    public function it_can_use_a_max_depth_option()
+    {
+        $sitemapPath = $this->temporaryDirectory->path('test.xml');
+
+        SitemapGenerator::create('http://localhost:4020')
+            ->setMaximumDepth(1)
+            ->writeToFile($sitemapPath);
+
+        $this->assertMatchesXmlSnapshot(file_get_contents($sitemapPath));
+    }
+
+    /** @test */
+    public function it_can_use_a_max_crawl_count_option()
+    {
+        $sitemapPath = $this->temporaryDirectory->path('test.xml');
+
+        SitemapGenerator::create('http://localhost:4020')
+            ->setMaximumCrawlCount(2)
+            ->writeToFile($sitemapPath);
+
+        $this->assertMatchesXmlSnapshot(file_get_contents($sitemapPath));
+    }
+
     protected function checkIfTestServerIsRunning()
     {
         try {

--- a/tests/__snapshots__/SitemapGeneratorTest__it_can_use_a_max_crawl_count_option__1.xml
+++ b/tests/__snapshots__/SitemapGeneratorTest__it_can_use_a_max_crawl_count_option__1.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>http://localhost:4020/</loc>
+    <lastmod>2016-01-01T00:00:00+00:00</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>http://localhost:4020/page1</loc>
+    <lastmod>2016-01-01T00:00:00+00:00</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/tests/__snapshots__/SitemapGeneratorTest__it_can_use_a_max_depth_option__1.xml
+++ b/tests/__snapshots__/SitemapGeneratorTest__it_can_use_a_max_depth_option__1.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>http://localhost:4020/</loc>
+    <lastmod>2016-01-01T00:00:00+00:00</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>http://localhost:4020/page1</loc>
+    <lastmod>2016-01-01T00:00:00+00:00</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>http://localhost:4020/page2</loc>
+    <lastmod>2016-01-01T00:00:00+00:00</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>http://localhost:4020/page3</loc>
+    <lastmod>2016-01-01T00:00:00+00:00</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
If you used the following code from the readme it doesn't work, the methods `setMaximumCrawlCount` and `setConcurrency` should return this, right?

```php
use Spatie\Sitemap\SitemapGenerator;
use Spatie\Crawler\Url;

SitemapGenerator::create('https://example.com')
    ->setMaximumCrawlCount(500) // only the 500 first pages will be crawled
    ->writeToFile(public_path('sitemap.xml'));
```