### PR TITLE
adds ability to chunk the sitemap generator

### DIFF
--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -36,6 +36,16 @@ class Sitemap
         return $this;
     }
 
+	/**
+	 * Returns tags
+	 *
+	 * @return array
+	 */
+	public function getTags()
+	{
+		return $this->tags;
+	}
+
     /**
      * @param string $url
      *

--- a/tests/SitemapGeneratorTest.php
+++ b/tests/SitemapGeneratorTest.php
@@ -30,6 +30,29 @@ class SitemapGeneratorTest extends TestCase
         $this->assertMatchesXmlSnapshot(file_get_contents($sitemapPath));
     }
 
+	/** @test */
+	public function it_can_generate_a_sitemap_with_chunk()
+	{
+		$sitemapPath = $this->temporaryDirectory->path('test_chunk.xml');
+
+		SitemapGenerator::create('http://localhost:4020')
+			->setChunck(1)
+			->writeToFile($sitemapPath);
+
+		$content = file_get_contents($sitemapPath);
+
+		foreach (range(0, 5) as $index) {
+			$filename = sprintf('test_chunk_%d.xml', $index);
+			$subsitemap = file_get_contents($this->temporaryDirectory->path($filename));
+
+			$this->assertNotEmpty($subsitemap);
+			$this->assertTrue((bool) preg_match('/test_chunk_' . $index . '\.xml/', $content));
+			$this->assertTrue((bool) preg_match('<loc>', $subsitemap));
+			$this->assertTrue((bool) preg_match('<url>', $subsitemap));
+			$this->assertTrue((bool) preg_match('<urlset>', $subsitemap));
+		}
+	}
+
     /** @test */
     public function it_can_modify_the_attributes_while_generating_the_sitemap()
     {


### PR DESCRIPTION
Related to #153 and for my professional use case. We have ~300 000 URLs to write in our sitemap dynamically. I'm not really familiar with `assertMatchesXmlSnapshot` so I hope my unit tests are readable