### PR TITLE
Adjust template format to improve render output

### DIFF
--- a/resources/views/url.blade.php
+++ b/resources/views/url.blade.php
@@ -2,22 +2,18 @@
     @if (! empty($tag->url))
     <loc>{{ $tag->url }}</loc>
     @endif
-
-    @if (count($tag->alternates))
-    @foreach ($tag->alternates as $alternate)
+@if (count($tag->alternates))
+@foreach ($tag->alternates as $alternate)
     <xhtml:link rel="alternate" hreflang="{{ $alternate->locale }}" href="{{ $alternate->url }}" />
     @endforeach
-    @endif
-
-    @if (! empty($tag->lastModificationDate))
+@endif
+@if (! empty($tag->lastModificationDate))
     <lastmod>{{ $tag->lastModificationDate->format(DateTime::ATOM) }}</lastmod>
-    @endif
-
+@endif
     @if (! empty($tag->changeFrequency))
     <changefreq>{{ $tag->changeFrequency }}</changefreq>
     @endif
-
-    @if (! empty($tag->priority))
+@if (! empty($tag->priority))
     <priority>{{ $tag->priority }}</priority>
     @endif
 </url>


### PR DESCRIPTION
Due to the way blade directives work indentation consistency of rendered content can get wonky. Normally this shouldn't be a big deal, browsers don't care about HTML indentation for rendering pages. However when you're using XML the use case for human readability is slightly more common.

In an effort to support and improve Human Readability this change adjusts the blade directives as necessary to improve indentation consistency with Sitemap XML structures.