### PR TITLE
Make methods on SitemapGenerator fluent

### DIFF
--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -70,11 +70,15 @@ class SitemapGenerator
     public function setConcurrency(int $concurrency)
     {
         $this->concurrency = $concurrency;
+        
+        return $this;
     }
 
     public function setMaximumCrawlCount(int $maximumCrawlCount)
     {
         $this->maximumCrawlCount = $maximumCrawlCount;
+        
+        return $this;
     }
 
     public function maxTagsPerSitemap(int $maximumTagsPerSitemap = 50000): self

--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -70,14 +70,14 @@ class SitemapGenerator
     public function setConcurrency(int $concurrency)
     {
         $this->concurrency = $concurrency;
-        
+
         return $this;
     }
 
     public function setMaximumCrawlCount(int $maximumCrawlCount)
     {
         $this->maximumCrawlCount = $maximumCrawlCount;
-        
+
         return $this;
     }
 


### PR DESCRIPTION
I tried doing the following:
```php
SitemapGenerator::create($applicationUrl)
            ->setMaximumCrawlCount(500)
            ->writeToFile($sitemapFilePath);
```

But  i noticed that that wont work, because `setMaximumCrawlCount` doesn't return `$this`. This PR makes all methods of SitemapGenerator that weren't fluent yet fluent.