### PR TITLE
Google will only accept fully qualified url's

### DIFF
--- a/src/Tags/Url.php
+++ b/src/Tags/Url.php
@@ -32,7 +32,7 @@ class Url extends Tag
 
     public static function create(string $url): self
     {
-        return new static($url);
+        return new static(url($url));
     }
 
     public function __construct(string $url)
@@ -101,7 +101,7 @@ class Url extends Tag
      */
     public function addAlternate(string $url, string $locale = '')
     {
-        $this->alternates[] = new Alternate($url, $locale);
+        $this->alternates[] = new Alternate(url($url), $locale);
 
         return $this;
     }


### PR DESCRIPTION
Google Search Console indicated to me that <loc>/en</loc> was not correct url. After some reading I verified:

https://support.google.com/webmasters/answer/183668?hl=en

> Use consistent, fully-qualified URLs. Google will crawl your URLs exactly as listed. For instance, if your site is at https://www.example.com/, don't specify a URL as https://example.com/ (missing www) or ./mypage.html (a relative URL).

https://support.google.com/webmasters/answer/189077?hl=en

> Alternate URLs must be fully-qualified, including the transport method (http/https), so:
 https://example.com/foo, not //example.com/foo or /foo

![screen shot 2018-09-05 at 21 01 56](https://user-images.githubusercontent.com/14302496/45118236-de9a7f80-b14f-11e8-8d8d-593c8d5c3f20.png)
