### PR TITLE
Fix Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ SitemapGenerator::create('https://example.com')
        // Links present on the contact page won't be added to the
        // sitemap unless they are present on a crawlable page.
        
-       return strpos($url->getPath(), '/contact') !== false;
+       return strpos($url->getPath(), '/contact') === false;
    })
    ->writeToFile($sitemapPath);
 ```


### PR DESCRIPTION
There was an error in the comparison operator used in the example for excluding pages while generating sitemaps.