### PR TITLE
Enforce priority value to be in the interval [0,1]

### DIFF
--- a/src/Tags/Url.php
+++ b/src/Tags/Url.php
@@ -87,7 +87,7 @@ class Url extends Tag
      */
     public function setPriority(float $priority)
     {
-        $this->priority = $priority;
+        $this->priority = max(0, min(1, $priority));
 
         return $this;
     }

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -63,6 +63,18 @@ class UrlTest extends TestCase
         $this->assertEquals(0.1, $this->url->priority);
     }
 
+    /** @test */
+    public function priority_is_clamped()
+    {
+        $this->url->setPriority(-0.1);
+
+        $this->assertEquals(0, $this->url->priority);
+
+        $this->url->setPriority(1.1);
+
+        $this->assertEquals(1, $this->url->priority);
+    }
+
     public function change_frequency_can_be_set()
     {
         $this->url->setChangeFrequency(Url::CHANGE_FREQUENCY_YEARLY);


### PR DESCRIPTION
Implementation from #144 but without the priority changes.

@Gummibeer:
> And to bring a usecase: if you generate a sitemap from your menu tree and say that every level reduces the priority by 0.2 and don't want to think about if it's valid.
* Home 1.0
  * Cat1 0.8
     * Cat2 0.6
       * Cat3 0.4
         * Cat4 0.2
           * Cat5 0.0
              * Articles -0.2 clamped to 0.0