### PR TITLE
Make urls in sitemapindex absoulte

### DIFF
--- a/resources/views/sitemapIndex/sitemap.blade.php
+++ b/resources/views/sitemapIndex/sitemap.blade.php
@@ -1,6 +1,6 @@
 <sitemap>
     @if (! empty($tag->url))
-    <loc>{{ $tag->url }}</loc>
+    <loc>{{ url($tag->url) }}</loc>
     @endif
 
     @if (! empty($tag->lastModificationDate))

--- a/tests/__snapshots__/SitemapIndexTest__a_sitemap_object_can_be_added_to_the_index__1.xml
+++ b/tests/__snapshots__/SitemapIndexTest__a_sitemap_object_can_be_added_to_the_index__1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
-    <loc>/sitemap1.xml</loc>
+    <loc>http://localhost/sitemap1.xml</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
   </sitemap>
 </sitemapindex>

--- a/tests/__snapshots__/SitemapIndexTest__an_url_string_can_be_added_to_the_index__1.xml
+++ b/tests/__snapshots__/SitemapIndexTest__an_url_string_can_be_added_to_the_index__1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
-    <loc>/sitemap1.xml</loc>
+    <loc>http://localhost/sitemap1.xml</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
   </sitemap>
 </sitemapindex>

--- a/tests/__snapshots__/SitemapIndexTest__it_can_render_a_sitemaps_with_all_its_set_properties__1.xml
+++ b/tests/__snapshots__/SitemapIndexTest__it_can_render_a_sitemaps_with_all_its_set_properties__1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
-    <loc>/sitemap1.xml</loc>
+    <loc>http://localhost/sitemap1.xml</loc>
     <lastmod>2015-12-31T00:00:00+00:00</lastmod>
   </sitemap>
 </sitemapindex>

--- a/tests/__snapshots__/SitemapIndexTest__multiple_sitemaps_can_be_added_to_the_index__1.xml
+++ b/tests/__snapshots__/SitemapIndexTest__multiple_sitemaps_can_be_added_to_the_index__1.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
-    <loc>/sitemap1.xml</loc>
+    <loc>http://localhost/sitemap1.xml</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
   </sitemap>
   <sitemap>
-    <loc>/sitemap2.xml</loc>
+    <loc>http://localhost/sitemap2.xml</loc>
     <lastmod>2016-01-01T00:00:00+00:00</lastmod>
   </sitemap>
 </sitemapindex>


### PR DESCRIPTION
Is there a reason why urls aren't absolute?