### PR TITLE
added sitemap namespace configuration

### DIFF
--- a/resources/views/sitemap.blade.php
+++ b/resources/views/sitemap.blade.php
@@ -1,6 +1,8 @@
 <?= '<'.'?'.'xml version="1.0" encoding="UTF-8"?>'."\n"; ?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<urlset <?= $namespaces ?> >
+
 @foreach($tags as $tag)
     @include('laravel-sitemap::' . $tag->getType())
 @endforeach
+
 </urlset>

--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -26,7 +26,7 @@ class Sitemap
             $tag = Url::create($tag);
         }
 
-        if (! in_array($tag, $this->tags)) {
+        if (!in_array($tag, $this->tags)) {
             $this->tags[] = $tag;
         }
 
@@ -47,7 +47,18 @@ class Sitemap
 
     public function hasUrl(string $url): bool
     {
-        return (bool) $this->getUrl($url);
+        return (bool)$this->getUrl($url);
+    }
+
+    /**
+     * @param array $namespaces
+     * @return Sitemap
+     */
+    public function setNamespaces(array $namespaces): self
+    {
+        SitemapNamespace::overrideNamespaces($namespaces);
+
+        return $this;
     }
 
     public function render(): string
@@ -56,14 +67,18 @@ class Sitemap
 
         $tags = $this->tags;
 
+        $namespaces = SitemapNamespace::generateNamespaces();
+
         return view('laravel-sitemap::sitemap')
-            ->with(compact('tags'))
+            ->with(compact('tags', "namespaces"))
             ->render();
     }
 
     public function writeToFile(string $path): self
     {
         file_put_contents($path, $this->render());
+
+        SitemapNamespace::setDefault();
 
         return $this;
     }

--- a/src/SitemapNamespace.php
+++ b/src/SitemapNamespace.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Spatie\Sitemap;
+
+
+class SitemapNamespace
+{
+    public static $namespaces = [
+        "xmlns" => "http://www.sitemaps.org/schemas/sitemap/0.9",
+        "xmlns:xhtml" => "http://www.w3.org/1999/xhtml"
+    ];
+
+    public static function overrideNamespaces($namespaces = [])
+    {
+        self::$namespaces = array_merge(self::$namespaces, $namespaces);
+    }
+
+    public static function generateNamespaces()
+    {
+        $result = "";
+        foreach (self::$namespaces as $key => $value) {
+            $result .= " " . $key . '="' . $value . '"';
+        }
+        return $result;
+    }
+
+    public static function setDefault()
+    {
+        self::$namespaces = [
+            "xmlns" => "http://www.sitemaps.org/schemas/sitemap/0.9",
+            "xmlns:xhtml" => "http://www.w3.org/1999/xhtml"
+        ];
+    }
+}


### PR DESCRIPTION
When generating multilingual sitemap, browsers doesn't treat those sitemap files as an xml file. When I googled it I found that there are many people having same problem. it seems `http://www.w3.org/1999/xhtml` namespace doesn't support `<xhtml:link />` tags so browsers crashing while rendering multilingual sitemap files which having this xhtml namespace..

Here you can get much more information.

[Google multilingual sitemap issue - Stackoverflow](https://stackoverflow.com/questions/24864254/google-multilingual-sitemap-issue)
[XML Sitemap rendering as plain text -Stackoverflow](https://stackoverflow.com/questions/51923627/xml-sitemap-rendering-as-plain-text?noredirect=1&lq=1)
[XML Namespace causeing browser to only display text - Google Webmaster Central Help Forum](https://productforums.google.com/forum/#!topic/webmasters/xqyE6lKWGJw;context-place=topicsearchin/webmasters/authorid$3AAPn2wQcbeJ21Qr7kXCe7rxcTISTs5emnJZxb62hsTMjT2npRLo_SS8-BqJjRlrfaj4koq5meFme1%7Csort:date%7Cspell:false)

So either solve this issue and provide to add custom namespaces to sitemaps I created this PR
```php
SitemapGenerator::create('https://example.com')
            ->getSitemap()
            ->add(...)
            ->setNamespaces([ # it will override default namespaces
                "xmlns:xhtml" => "http://www.w3.org/TR/xhtml11/xhtml11_schema.html",
                "xmlns:image" => "http://www.google.com/schemas/sitemap-image/1.1",
                "xmlns:video" => "http://www.google.com/schemas/sitemap-video/1.1"
                // etc..
            ])
            ->writeToFile(public_path("/sitemap.xml"));
/*
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
        xmlns:xhtml="http://www.w3.org/TR/xhtml11/xhtml11_schema.html"
        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
        xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
*/
```
