### PR TITLE
Use php dom extension to format xml output

### DIFF
--- a/resources/views/header.blade.php
+++ b/resources/views/header.blade.php
@@ -1,0 +1,1 @@
+{!! '<?xml version="1.0" encoding="UTF-8"?>' !!}

--- a/resources/views/sitemap.blade.php
+++ b/resources/views/sitemap.blade.php
@@ -1,6 +1,5 @@
-<?= '<'.'?'.'xml version="1.0" encoding="UTF-8"?>'."\n"; ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-@foreach($tags as $tag)
-    @include('laravel-sitemap::' . $tag->getType())
-@endforeach
+	@foreach($tags as $tag)
+	    @include('laravel-sitemap::' . $tag->getType())
+	@endforeach
 </urlset>

--- a/resources/views/url.blade.php
+++ b/resources/views/url.blade.php
@@ -1,19 +1,23 @@
 <url>
     @if (! empty($tag->url))
-    <loc>{{ url($tag->url) }}</loc>
+        <loc>{{ url($tag->url) }}</loc>
     @endif
-@if (count($tag->alternates))
-@foreach ($tag->alternates as $alternate)
-    <xhtml:link rel="alternate" hreflang="{{ $alternate->locale }}" href="{{ url($alternate->url) }}" />
-    @endforeach
-@endif
-@if (! empty($tag->lastModificationDate))
-    <lastmod>{{ $tag->lastModificationDate->format(DateTime::ATOM) }}</lastmod>
-@endif
+
+    @if (count($tag->alternates))
+        @foreach ($tag->alternates as $alternate)
+            <xhtml:link rel="alternate" hreflang="{{ $alternate->locale }}" href="{{ url($alternate->url) }}" />
+        @endforeach
+    @endif
+
+    @if (! empty($tag->lastModificationDate))
+        <lastmod>{{ $tag->lastModificationDate->format(DateTime::ATOM) }}</lastmod>
+    @endif
+
     @if (! empty($tag->changeFrequency))
-    <changefreq>{{ $tag->changeFrequency }}</changefreq>
+        <changefreq>{{ $tag->changeFrequency }}</changefreq>
     @endif
-@if (! empty($tag->priority))
-    <priority>{{ number_format($tag->priority,1) }}</priority>
+
+    @if (! empty($tag->priority))
+        <priority>{{ $tag->priority }}</priority>
     @endif
 </url>

--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -39,6 +39,9 @@ class SitemapGenerator
     /** @var int|null */
     protected $maximumCrawlCount = null;
 
+    /** @var bool */
+    protected $formatDocument = false;
+
     /**
      * @param string $urlToBeCrawled
      *
@@ -99,6 +102,13 @@ class SitemapGenerator
         return $this;
     }
 
+    public function setFormatDocument(bool $formatDocument = true)
+    {
+        $this->formatDocument = $formatDocument;
+
+        return $this;
+    }
+
     public function shouldCrawl(callable $shouldCrawl)
     {
         $this->shouldCrawl = $shouldCrawl;
@@ -139,7 +149,7 @@ class SitemapGenerator
      */
     public function writeToFile(string $path)
     {
-        $sitemap = $this->getSitemap();
+        $sitemap = $this->getSitemap()->setFormatDocument($this->formatDocument);
 
         if ($this->maximumTagsPerSitemap) {
             $sitemap = SitemapIndex::create();


### PR DESCRIPTION
1. Format the code in the blade templates with correct indents.

2. Extract the xml header to it's own file to add it back later on.
We do this because DOMDocument removes this tag in the process.

3. Add `setFormatDocument` method to the `SitemapGenerator` class. This
formats the xml output using php dom extension, if it's is available.

4. Change the way the xml header is put together, to a more convenient
approach.

Example output

```
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
  <url>
    <loc>https://www.example.com</loc>
    <lastmod>2019-03-11T22:09:56+00:00</lastmod>
    <changefreq>daily</changefreq>
    <priority>0,8</priority>
  </url>
  <url>
    <loc>https://www.example.com/</loc>
    <lastmod>2019-03-11T22:09:56+00:00</lastmod>
    <changefreq>daily</changefreq>
    <priority>0,8</priority>
  </url>
  <url>
    <loc>https://www.example.com/contact-us</loc>
    <lastmod>2019-03-11T22:09:56+00:00</lastmod>
    <changefreq>daily</changefreq>
    <priority>0,8</priority>
  </url>
</urlset>
```

Could probably also use SimpleXml (as fallback?). Would appreciate your opinion. http://php.net/manual/en/book.simplexml.php