### PR TITLE
Added unique to render function to prevent duplicate URLs

### DIFF
--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -54,7 +54,7 @@ class Sitemap
     {
         sort($this->tags);
 
-        $tags = $this->tags;
+        $tags = collect($this->tags)->unique('url');
 
         return view('laravel-sitemap::sitemap')
             ->with(compact('tags'))

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -135,4 +135,13 @@ class SitemapTest extends TestCase
 
         $this->assertNull($this->sitemap->getUrl('/page2'));
     }
+
+    /** @test */
+    public function a_url_object_can_not_be_added_twice_to_the_sitemap()
+    {
+        $this->sitemap->add(Url::create('/home'));
+        $this->sitemap->add(Url::create('/home'));
+
+        $this->assertMatchesXmlSnapshot($this->sitemap->render());
+    }
 }

--- a/tests/__snapshots__/SitemapTest__a_url_object_can_not_be_added_twice_to_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapTest__a_url_object_can_not_be_added_twice_to_the_sitemap__1.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>http://localhost/home</loc>
+    <lastmod>2016-01-01T00:00:00+00:00</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
As mentioned in #257 because there is no `unique()` call to prevent duplicate URL's you can get duplicate URLs by using the `URL`-object. 

This PR prevents this behavior.