### PR TITLE
Implement Responsable contract

### DIFF
--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\Sitemap;
 
-use Illuminate\Contracts\Support\Responsable;
-use Illuminate\Support\Facades\Response;
 use Spatie\Sitemap\Tags\Tag;
 use Spatie\Sitemap\Tags\Url;
+use Illuminate\Support\Facades\Response;
+use Illuminate\Contracts\Support\Responsable;
 
 class Sitemap implements Responsable
 {

--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -2,10 +2,12 @@
 
 namespace Spatie\Sitemap;
 
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Facades\Response;
 use Spatie\Sitemap\Tags\Tag;
 use Spatie\Sitemap\Tags\Url;
 
-class Sitemap
+class Sitemap implements Responsable
 {
     /** @var array */
     protected $tags = [];
@@ -66,5 +68,18 @@ class Sitemap
         file_put_contents($path, $this->render());
 
         return $this;
+    }
+
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        return Response::make($this->render(), 200, [
+            'Content-Type' => 'text/xml',
+        ]);
     }
 }

--- a/src/SitemapIndex.php
+++ b/src/SitemapIndex.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\Sitemap;
 
-use Illuminate\Contracts\Support\Responsable;
-use Illuminate\Support\Facades\Response;
 use Spatie\Sitemap\Tags\Tag;
 use Spatie\Sitemap\Tags\Sitemap;
+use Illuminate\Support\Facades\Response;
+use Illuminate\Contracts\Support\Responsable;
 
 class SitemapIndex implements Responsable
 {

--- a/src/SitemapIndex.php
+++ b/src/SitemapIndex.php
@@ -2,10 +2,12 @@
 
 namespace Spatie\Sitemap;
 
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Facades\Response;
 use Spatie\Sitemap\Tags\Tag;
 use Spatie\Sitemap\Tags\Sitemap;
 
-class SitemapIndex
+class SitemapIndex implements Responsable
 {
     /** @var array */
     protected $tags = [];
@@ -84,5 +86,18 @@ class SitemapIndex
         file_put_contents($path, $this->render());
 
         return $this;
+    }
+
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        return Response::make($this->render(), 200, [
+            'Content-Type' => 'text/xml',
+        ]);
     }
 }

--- a/tests/SitemapIndexTest.php
+++ b/tests/SitemapIndexTest.php
@@ -118,8 +118,8 @@ class SitemapIndexTest extends TestCase
     /** @test */
     public function an_instance_can_return_a_response()
     {
-        $this->sitemap->add(Url::create('/home'));
+        $this->index->add('/sitemap1.xml');
 
-        $this->assertInstanceOf(Response::class, $this->sitemap->toResponse(new Request));
+        $this->assertInstanceOf(Response::class, $this->index->toResponse(new Request));
     }
 }

--- a/tests/SitemapIndexTest.php
+++ b/tests/SitemapIndexTest.php
@@ -4,6 +4,8 @@ namespace Spatie\Sitemap\Test;
 
 use Spatie\Sitemap\SitemapIndex;
 use Spatie\Sitemap\Tags\Sitemap;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class SitemapIndexTest extends TestCase
 {
@@ -111,5 +113,13 @@ class SitemapIndexTest extends TestCase
         $this->assertNotNull($this->index->getSitemap('/sitemap1.xml'));
 
         $this->assertNull($this->index->getSitemap('/sitemap2.xml'));
+    }
+
+    /** @test */
+    public function an_instance_can_return_a_response()
+    {
+        $this->sitemap->add(Url::create('/home'));
+
+        $this->assertInstanceOf(Response::class, $this->sitemap->toResponse(new Request));
     }
 }

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -4,6 +4,8 @@ namespace Spatie\Sitemap\Test;
 
 use Spatie\Sitemap\Sitemap;
 use Spatie\Sitemap\Tags\Url;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class SitemapTest extends TestCase
 {
@@ -143,5 +145,13 @@ class SitemapTest extends TestCase
         $this->sitemap->add(Url::create('/home'));
 
         $this->assertMatchesXmlSnapshot($this->sitemap->render());
+    }
+
+    /** @test */
+    public function an_instance_can_return_a_response()
+    {
+        $this->sitemap->add(Url::create('/home'));
+
+        $this->assertInstanceOf(Response::class, $this->sitemap->toResponse(new Request));
     }
 }


### PR DESCRIPTION
This updates `Sitemap` and `SitemapIndex` to implement the `Responsable` contract, meaning an instance of them can simply be returned as an HTTP response. It's a lazy alternative to pre-generating sitemaps and means you can just built one up and return it in a controller.

```php
$sitemap = Sitemap::create();

$sitemap->add(Url::create('https://www.laravel.com'));

return $sitemap;
```

Granted, they could implement the `Renderable` contract too but decided to keep this as simple as possible. Also ordered the imports alphabetically because that's how the cool kids do it now - will see how StyleCI likes it.