### PR TITLE
Add missing use in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ This will copy the default config to `config/sitemap.php` where you can edit it.
 
 ```php
 use GuzzleHttp\RequestOptions;
+use Spatie\Sitemap\Crawler\Profile;
 
 return [
 


### PR DESCRIPTION
I added a missing use in the readme. Not very important, but it can confuse someone. 