### PR TITLE
Update README to use path() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ class CustomCrawlProfile extends CrawlProfile
             return false;
         }
         
-        return $url->getPath() === '/';
+        return $url->path() === '/';
     }
 }
 ```
@@ -271,7 +271,7 @@ SitemapGenerator::create('https://example.com')
        // Links present on the contact page won't be added to the
        // sitemap unless they are present on a crawlable page.
        
-       return strpos($url->getPath(), '/contact') === false;
+       return strpos($url->path(), '/contact') === false;
    })
    ->writeToFile($sitemapPath);
 ```


### PR DESCRIPTION
Update README file to use `path()` instead of `getPath()` as that function doesn't exist. 

See https://github.com/spatie/laravel-sitemap/blob/master/src/Tags/Url.php#L112