### PR TITLE
Update README to use correct writeToDisk() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The generator has [the ability to execute JavaScript](https://github.com/spatie/
 
 You can also use one of your available filesystem disks to write the sitemap to.
 ```php
-SitemapGenerator::create('https://example.com')->writeToDisk('public', 'sitemap.xml');
+SitemapGenerator::create('https://example.com')->getSitemap()->writeToDisk('public', 'sitemap.xml');
 ```
 
 ## Support us


### PR DESCRIPTION
The SitemapGenerator class does not have a writeToDisk() function, only the Sitemap and SitemapIndex classes do. 

This PR updates the example provided in the README.