### PR TITLE
Update README to use getPath()

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ class CustomCrawlProfile extends CrawlProfile
             return false;
         }
         
-        return $url->path() === '/';
+        return $url->getPath() === '/';
     }
 }
 ```
@@ -277,7 +277,7 @@ SitemapGenerator::create('https://example.com')
        // Links present on the contact page won't be added to the
        // sitemap unless they are present on a crawlable page.
        
-       return strpos($url->path(), '/contact') === false;
+       return strpos($url->getPath(), '/contact') === false;
    })
    ->writeToFile($sitemapPath);
 ```


### PR DESCRIPTION
[Psr\Http\Message\UriInterface](https://www.php-fig.org/psr/psr-7/) used in the examples comes with `getPath()`, and does not include a `path()` method.

I may be missing out something, but strangely, this was changed in a [recent commit](https://github.com/spatie/laravel-sitemap/commit/0d0fe8ae5bc9a9c4894e01aa652309970127f10b). 