### PR TITLE
Update Sitemap.php, Add filter() method to tags before rendering

### DIFF
--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -57,7 +57,7 @@ class Sitemap implements Responsable
     {
         sort($this->tags);
 
-        $tags = collect($this->tags)->unique('url');
+        $tags = collect($this->tags)->unique('url')->filter();
 
         return view('laravel-sitemap::sitemap')
             ->with(compact('tags'))


### PR DESCRIPTION
For some reason there are empty tags in the array, which results in the error:
Call to a member function getType() on null

The ->filter() method makes sure there are never empty tags in the view.