### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ use Spatie\Sitemap\Tags\Url;
 
 class Post extends Model implements Sitemapable
 {
-    public function toSitemapTag() : Url | string | array{
+    public function toSitemapTag() : Url | string | array
+    {
         return route('blog.post.show', $this);
     }
 }

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ use Spatie\Sitemap\Tags\Url;
 
 class Post extends Model implements Sitemapable
 {
-    public function toSitemapTag() : Url | string | array
+    public function toSitemapTag(): Url | string | array
     {
         return route('blog.post.show', $this);
     }


### PR DESCRIPTION
Fixed a small code style typo in the `README` that was bugging me. 👍

### Before 

```php
class Post extends Model implements Sitemapable
{
    public function toSitemapTag() : Url | string | array{
        return route('blog.post.show', $this);
    }
}
```

### After

```php
class Post extends Model implements Sitemapable
{
    public function toSitemapTag(): Url | string | array
    {
        return route('blog.post.show', $this);
    }
}
```