### PR TITLE
Bump temporary-directory to version 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "orchestra/testbench": "^6.0",
         "phpunit/phpunit": "^9.3",
         "spatie/phpunit-snapshot-assertions": "^4.0",
-        "spatie/temporary-directory": "^1.1"
+        "spatie/temporary-directory": "^2.0"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
We cannot use Mailcoach together with this package because Mailcoach requires 2.0.

Just like https://github.com/spatie/browsershot/pull/495 ;)

`spatie/crawler` probably also needs to be bumped when `spatie/browsershot` is bumped.