### PR TITLE
Fix maximum crawl count

### DIFF
--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -114,7 +114,7 @@ class SitemapGenerator
         }
 
         if (! is_null($this->maximumCrawlCount)) {
-            $this->crawler->setTotalCrawlLimit($this->maximumCrawlCount);
+            $this->crawler->setMaximumCrawlCount($this->maximumCrawlCount);
         }
 
         $this->crawler


### PR DESCRIPTION
Currently the `laravel-sitemap` plugin has no way to natively set the maximum crawl count due to a call that uses the wrong (old?) method name on the `Spatie\Crawler\Crawler` class. 