### PR TITLE
Revert "fix for maximum crawl limit (#470)"

### DIFF
--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -114,7 +114,7 @@ class SitemapGenerator
         }
 
         if (! is_null($this->maximumCrawlCount)) {
-            $this->crawler->setMaximumCrawlCount($this->maximumCrawlCount);
+            $this->crawler->setTotalCrawlLimit($this->maximumCrawlCount);
         }
 
         $this->crawler


### PR DESCRIPTION
This reverts commit 6527aa95746b35fbaf6254b773bd99f147fe4f77.

The commit is completely wrong. The old function was correct, the new one doesn't exist in the `spatie/crawler` package.
Exception and more info on https://github.com/spatie/laravel-sitemap/discussions/485.