### PR TITLE
Add video tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,44 @@ Sitemap::create()
     ->writeToFile($sitemapPath);
 ```
 
+#### Adding videos to links
+
+As well as images, videos can be wrapped by URL tags. See https://developers.google.com/search/docs/crawling-indexing/sitemaps/video-sitemaps
+
+You can set required attributes like so:
+
+```php
+use Spatie\Sitemap\Sitemap;
+use Spatie\Sitemap\Tags\Url;
+
+Sitemap::create()
+    ->add(
+        Url::create('https://example.com')
+            ->addVideo('https://example.com/images/thumbnail.jpg', 'Video title', 'Video Description', 'https://example.com/videos/source.mp4', 'https://example.com/video/123')
+    )
+    ->writeToFile($sitemapPath);
+```
+
+If you want to pass the optional parameters like `family_friendly`, `live`, or `platform`:
+
+```php
+use Spatie\Sitemap\Sitemap;
+use Spatie\Sitemap\Tags\Url;
+use Spatie\Sitemap\Tags\Video;
+
+
+$options = ['family_friendly' => Video::BOOL_TRUE, 'live' => Video::BOOL_FALSE];
+$allowOptions = ['platform' => Video::PLATFORM_MOBILE];
+$denyOptions = ['restriction' => 'CA'];
+
+Sitemap::create()
+    ->add(
+        Url::create('https://example.com')
+            ->addVideo('https://example.com/images/thumbnail.jpg', 'Video title', 'Video Description', 'https://example.com/videos/source.mp4', 'https://example.com/video/123', $options, $allowOptions, $denyOptions)
+    )
+    ->writeToFile($sitemapPath);
+```
+
 ### Manually creating a sitemap
 
 You can also create a sitemap fully manual:

--- a/resources/views/url.blade.php
+++ b/resources/views/url.blade.php
@@ -17,4 +17,5 @@
     <priority>{{ number_format($tag->priority,1) }}</priority>
     @endif
     @each('sitemap::image', $tag->images, 'image')
+    @each('sitemap::video', $tag->videos, 'video')
 </url>

--- a/resources/views/video.blade.php
+++ b/resources/views/video.blade.php
@@ -9,6 +9,6 @@
     <video:player_loc>{{ $video->playerLoc }}</video:player_loc>
 @endif
 @if ($video->platforms && count($video->platforms) > 0)
-    <video:platform relationship="allow">{{ implode(" ", $video->playerLoc) }}</video:platform>
+    <video:platform relationship="allow">{{ implode(" ", $video->platforms) }}</video:platform>
 @endif
 </video:video>

--- a/resources/views/video.blade.php
+++ b/resources/views/video.blade.php
@@ -9,6 +9,6 @@
     <video:player_loc>{{ $video->playerLoc }}</video:player_loc>
 @endif
 @if ($video->platforms && count($video->platforms) > 0)
-    <video:platform relationship="allow">{{ implode($video->playerLoc, " ") }}</video:platform>
+    <video:platform relationship="allow">{{ implode(" ", $video->playerLoc) }}</video:platform>
 @endif
 </video:video>

--- a/resources/views/video.blade.php
+++ b/resources/views/video.blade.php
@@ -8,7 +8,16 @@
 @if ($video->playerLoc)
     <video:player_loc>{{ $video->playerLoc }}</video:player_loc>
 @endif
-@if ($video->platforms && count($video->platforms) > 0)
-    <video:platform relationship="allow">{{ implode(" ", $video->platforms) }}</video:platform>
-@endif
+@foreach($video->options as $tag => $value)
+    <video:{{$tag}}>{{$value}}</video:{{$tag}}>
+@endforeach
+@foreach($video->allow as $tag => $value)
+    <video:{{$tag}} relationship="allow">{{$value}}</video:{{$tag}}>
+@endforeach
+@foreach($video->deny as $tag => $value)
+    <video:{{$tag}} relationship="deny">{{$value}}</video:{{$tag}}>
+@endforeach
+{{--@if ($video->platforms && count($video->platforms) > 0)--}}
+{{--    <video:platform relationship="allow">{{ implode(" ", $video->platforms) }}</video:platform>--}}
+{{--@endif--}}
 </video:video>

--- a/resources/views/video.blade.php
+++ b/resources/views/video.blade.php
@@ -1,0 +1,14 @@
+<video:video>
+    <video:thumbnail_loc>{{ url($video->thumbnailLoc) }}</video:thumbnail_loc>
+    <video:title>{{ url($video->title) }}</video:title>
+    <video:description>{{ url($video->description) }}</video:description>
+@if ($video->contentLoc)
+    <video:content_loc>{{ url($video->contentLoc) }}</video:content_loc>
+@endif
+@if ($video->playerLoc)
+    <video:player_loc>{{ url($video->playerLoc) }}</video:player_loc>
+@endif
+@if ($video->platforms && count($video->platforms) > 0)
+    <video:platform relationship="allow">{{ implode($video->playerLoc, " ") }}</video:platform>
+@endif
+</video:video>

--- a/resources/views/video.blade.php
+++ b/resources/views/video.blade.php
@@ -1,12 +1,12 @@
 <video:video>
-    <video:thumbnail_loc>{{ url($video->thumbnailLoc) }}</video:thumbnail_loc>
-    <video:title>{{ url($video->title) }}</video:title>
-    <video:description>{{ url($video->description) }}</video:description>
+    <video:thumbnail_loc>{{ $video->thumbnailLoc }}</video:thumbnail_loc>
+    <video:title>{{ $video->title }}</video:title>
+    <video:description>{{ $video->description }}</video:description>
 @if ($video->contentLoc)
-    <video:content_loc>{{ url($video->contentLoc) }}</video:content_loc>
+    <video:content_loc>{{ $video->contentLoc }}</video:content_loc>
 @endif
 @if ($video->playerLoc)
-    <video:player_loc>{{ url($video->playerLoc) }}</video:player_loc>
+    <video:player_loc>{{ $video->playerLoc }}</video:player_loc>
 @endif
 @if ($video->platforms && count($video->platforms) > 0)
     <video:platform relationship="allow">{{ implode($video->playerLoc, " ") }}</video:platform>

--- a/resources/views/video.blade.php
+++ b/resources/views/video.blade.php
@@ -17,7 +17,4 @@
 @foreach($video->deny as $tag => $value)
     <video:{{$tag}} relationship="deny">{{$value}}</video:{{$tag}}>
 @endforeach
-{{--@if ($video->platforms && count($video->platforms) > 0)--}}
-{{--    <video:platform relationship="allow">{{ implode(" ", $video->platforms) }}</video:platform>--}}
-{{--@endif--}}
 </video:video>

--- a/src/Tags/Url.php
+++ b/src/Tags/Url.php
@@ -29,6 +29,9 @@ class Url extends Tag
     /** @var \Spatie\Sitemap\Tags\Image[] */
     public array $images = [];
 
+    /** @var \Spatie\Sitemap\Tags\Video[] */
+    public array $videos = [];
+
     public static function create(string $url): static
     {
         return new static($url);
@@ -81,6 +84,13 @@ class Url extends Tag
     public function addImage(string $url, string $caption = '', string $geo_location = '', string $title = '', string $license = ''): static
     {
         $this->images[] = new Image($url, $caption, $geo_location, $title, $license);
+
+        return $this;
+    }
+
+    public function addVideo(string $thumbnailLoc, string $title, string $description, $contentLoc = null, $playerLoc = null, array $platforms = []): static
+    {
+        $this->videos[] = new Video($thumbnailLoc, $title, $description, $contentLoc, $playerLoc, $platforms);
 
         return $this;
     }

--- a/src/Tags/Url.php
+++ b/src/Tags/Url.php
@@ -88,9 +88,9 @@ class Url extends Tag
         return $this;
     }
 
-    public function addVideo(string $thumbnailLoc, string $title, string $description, $contentLoc = null, $playerLoc = null, array $platforms = []): static
+    public function addVideo(string $thumbnailLoc, string $title, string $description, $contentLoc = null, $playerLoc = null, array $options = [], array $allow = [], array $deny = []): static
     {
-        $this->videos[] = new Video($thumbnailLoc, $title, $description, $contentLoc, $playerLoc, $platforms);
+        $this->videos[] = new Video($thumbnailLoc, $title, $description, $contentLoc, $playerLoc, $options, $allow, $deny);
 
         return $this;
     }

--- a/src/Tags/Video.php
+++ b/src/Tags/Video.php
@@ -17,9 +17,9 @@ class Video
 
     public string $description;
 
-    public string $contentLoc;
+    public ?string $contentLoc;
 
-    public string $playerLoc;
+    public ?string $playerLoc;
 
     public array $options;
 
@@ -65,14 +65,14 @@ class Video
         return $this;
     }
 
-    public function setContentLoc(string $contentLoc): self
+    public function setContentLoc(?string $contentLoc): self
     {
         $this->contentLoc = $contentLoc;
 
         return $this;
     }
 
-    public function setPlayerLoc(string $playerLoc): self
+    public function setPlayerLoc(?string $playerLoc): self
     {
         $this->playerLoc = $playerLoc;
 

--- a/src/Tags/Video.php
+++ b/src/Tags/Video.php
@@ -18,9 +18,13 @@ class Video
 
     public string $playerLoc;
 
-    public ?array $platforms;
+    public array $options;
 
-    public function __construct(string $thumbnailLoc, string $title, string $description, string $contentLoc = null, string $playerLoc = null, ?array $platforms = null)
+    public array $allow;
+
+    public array $deny;
+
+    public function __construct(string $thumbnailLoc, string $title, string $description, string $contentLoc = null, string $playerLoc = null, array $options = [], array $allow = [], array $deny = [])
     {
         if ($contentLoc === null && $playerLoc === null) {
             // https://developers.google.com/search/docs/crawling-indexing/sitemaps/video-sitemaps
@@ -32,7 +36,9 @@ class Video
             ->setDescription($description)
             ->setContentLoc($contentLoc)
             ->setPlayerLoc($playerLoc)
-            ->setPlatforms($platforms);
+            ->setOptions($options)
+            ->setAllow($allow)
+            ->setDeny($deny);
     }
 
     public function setThumbnailLoc(string $thumbnailLoc): self
@@ -70,9 +76,23 @@ class Video
         return $this;
     }
 
-    public function setPlatforms(?array $platforms): self
+    public function setOptions(?array $options): self
     {
-        $this->platforms = $platforms;
+        $this->options = $options;
+
+        return $this;
+    }
+
+    public function setAllow(array $allow): self
+    {
+        $this->allow = $allow;
+
+        return $this;
+    }
+
+    public function setDeny(array $deny): self
+    {
+        $this->deny = $deny;
 
         return $this;
     }

--- a/src/Tags/Video.php
+++ b/src/Tags/Video.php
@@ -8,6 +8,9 @@ class Video
     public const PLATFORM_MOBILE = 'mobile';
     public const PLATFORM_TV     = 'tv';
 
+    public const BOOL_FALSE      = "no";
+    public const BOOL_TRUE       = "yes";
+
     public string $thumbnailLoc;
 
     public string $title;

--- a/src/Tags/Video.php
+++ b/src/Tags/Video.php
@@ -18,13 +18,13 @@ class Video
 
     public string $playerLoc;
 
-    public array $platforms;
+    public ?array $platforms;
 
-    public function __construct(string $thumbnailLoc, string $title, string $description, $contentLoc = null, $playerLoc = null, array $platforms = [])
+    public function __construct(string $thumbnailLoc, string $title, string $description, string $contentLoc = null, string $playerLoc = null, ?array $platforms = null)
     {
         if ($contentLoc === null && $playerLoc === null) {
             // https://developers.google.com/search/docs/crawling-indexing/sitemaps/video-sitemaps
-            throw new \RuntimeException("It's required to provide either a Content Location or Player Location");
+            throw new \Exception("It's required to provide either a Content Location or Player Location");
         }
 
         $this->setThumbnailLoc($thumbnailLoc)
@@ -70,7 +70,7 @@ class Video
         return $this;
     }
 
-    public function setPlatforms(array $platforms): self
+    public function setPlatforms(?array $platforms): self
     {
         $this->platforms = $platforms;
 

--- a/src/Tags/Video.php
+++ b/src/Tags/Video.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Spatie\Sitemap\Tags;
+
+class Video
+{
+    public const PLATFORM_WEB    = 'web';
+    public const PLATFORM_MOBILE = 'mobile';
+    public const PLATFORM_TV     = 'tv';
+
+    public string $thumbnailLoc;
+
+    public string $title;
+
+    public string $description;
+
+    public string $contentLoc;
+
+    public string $playerLoc;
+
+    public array $platforms;
+
+    public function __construct(string $thumbnailLoc, string $title, string $description, $contentLoc = null, $playerLoc = null, array $platforms = [])
+    {
+        if ($contentLoc === null && $playerLoc === null) {
+            // https://developers.google.com/search/docs/crawling-indexing/sitemaps/video-sitemaps
+            throw new \RuntimeException("It's required to provide either a Content Location or Player Location");
+        }
+
+        $this->setThumbnailLoc($thumbnailLoc)
+            ->setTitle($title)
+            ->setDescription($description)
+            ->setContentLoc($contentLoc)
+            ->setPlayerLoc($playerLoc)
+            ->setPlatforms($platforms);
+    }
+
+    public function setThumbnailLoc(string $thumbnailLoc): self
+    {
+        $this->thumbnailLoc = $thumbnailLoc;
+
+        return $this;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function setContentLoc(string $contentLoc): self
+    {
+        $this->contentLoc = $contentLoc;
+
+        return $this;
+    }
+
+    public function setPlayerLoc(string $playerLoc): self
+    {
+        $this->playerLoc = $playerLoc;
+
+        return $this;
+    }
+
+    public function setPlatforms(array $platforms): self
+    {
+        $this->platforms = $platforms;
+
+        return $this;
+    }
+}

--- a/tests/VideoTest.php
+++ b/tests/VideoTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Carbon\Carbon;
+use Spatie\Sitemap\Sitemap;
+use Spatie\Sitemap\Tags\Url;
+
+test('XML has Video tag', function () {
+    $expected_xml = '<?xml version="1.0" encoding="UTF-8"?>
+                        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+                            <url>
+                                <loc>https://example.com</loc>
+                                <lastmod>2022-12-31T20:30:00+00:00</lastmod>
+                                <changefreq>daily</changefreq>
+                                <priority>0.8</priority>
+                                <video:video>
+                                    <video:thumbnail_loc>https://example.com/image.jpg</video:thumbnail_loc>
+                                    <video:title>My Test Title</video:title>
+                                    <video:description>My Test Description</video:description>
+                                    <video:content_loc>https://example.com/video.mp4</video:content_loc>
+                                    <video:live>no</video:live>
+                                    <video:family_friendly>yes</video:family_friendly>
+                                    <video:platform relationship="allow">mobile</video:platform>
+                                    <video:restriction relationship="deny">CA</video:restriction>
+                                </video:video>
+                            </url>
+                        </urlset>';
+
+    $sitemap = Sitemap::create()
+        ->add(
+            Url::create("https://example.com")
+                ->setLastModificationDate(Carbon::parse('2023-01-01 00:00:00')->setTimezone('+00:00'))
+                ->addVideo("https://example.com/image.jpg", "My Test Title", "My Test Description", "https://example.com/video.mp4", null, $options, $allow, $deny)
+        );
+
+    $render_output = $sitemap->render();
+
+    expect($render_output)->toEqualXmlString($expected_xml);
+});

--- a/tests/VideoTest.php
+++ b/tests/VideoTest.php
@@ -3,13 +3,14 @@
 use Carbon\Carbon;
 use Spatie\Sitemap\Sitemap;
 use Spatie\Sitemap\Tags\Url;
+use Spatie\Sitemap\Tags\Video;
 
 test('XML has Video tag', function () {
     $expected_xml = '<?xml version="1.0" encoding="UTF-8"?>
                         <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
                             <url>
                                 <loc>https://example.com</loc>
-                                <lastmod>2022-12-31T20:30:00+00:00</lastmod>
+                                <lastmod>2016-01-01T00:00:00+00:00</lastmod>
                                 <changefreq>daily</changefreq>
                                 <priority>0.8</priority>
                                 <video:video>
@@ -24,11 +25,13 @@ test('XML has Video tag', function () {
                                 </video:video>
                             </url>
                         </urlset>';
-
+    
+    $options = ["live" => "no", "family_friendly" => "yes"];
+    $allow = ["platform" => Video::PLATFORM_MOBILE];
+    $deny = ["restriction" => 'CA'];
     $sitemap = Sitemap::create()
         ->add(
             Url::create("https://example.com")
-                ->setLastModificationDate(Carbon::parse('2023-01-01 00:00:00')->setTimezone('+00:00'))
                 ->addVideo("https://example.com/image.jpg", "My Test Title", "My Test Description", "https://example.com/video.mp4", null, $options, $allow, $deny)
         );
 


### PR DESCRIPTION
I've added the `video:video` tag which supports all required and optional related parameters.

Reference: https://developers.google.com/search/docs/crawling-indexing/sitemaps/video-sitemaps