### PR TITLE
Remove default lastModificationDate = now()

### DIFF
--- a/src/Tags/Url.php
+++ b/src/Tags/Url.php
@@ -41,8 +41,6 @@ class Url extends Tag
     {
         $this->url = $url;
 
-        $this->lastModificationDate = Carbon::now();
-
         $this->changeFrequency = static::CHANGE_FREQUENCY_DAILY;
     }
 


### PR DESCRIPTION
Based on the latest Google' Search documentation (https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping#the-lastmod-element)

> Second, it needs to consistently match reality: if your page changed 7 years ago, but you're telling us in the lastmod element that it changed yesterday, eventually we're not going to believe you anymore when it comes to the last modified date of your pages.