### PR TITLE
Allow priority value of `0`

### DIFF
--- a/resources/views/url.blade.php
+++ b/resources/views/url.blade.php
@@ -13,9 +13,7 @@
     @if (! empty($tag->changeFrequency))
     <changefreq>{{ $tag->changeFrequency }}</changefreq>
     @endif
-@if (! empty($tag->priority))
     <priority>{{ number_format($tag->priority,1) }}</priority>
-    @endif
     @each('sitemap::image', $tag->images, 'image')
     @each('sitemap::video', $tag->videos, 'video')
 </url>

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -87,6 +87,18 @@ it('can render an url with all its set properties', function () {
     assertMatchesXmlSnapshot($this->sitemap->render());
 });
 
+it('can render an url with priority 0', function () {
+    $this->sitemap
+        ->add(
+            Url::create('/home')
+                ->setLastModificationDate($this->now->subDay())
+                ->setChangeFrequency(Url::CHANGE_FREQUENCY_YEARLY)
+                ->setPriority(0.0)
+        );
+
+    assertMatchesXmlSnapshot($this->sitemap->render());
+});
+
 it('can determine if it contains a given url', function () {
     $this->sitemap
         ->add('/page1')

--- a/tests/__snapshots__/SitemapTest__it_can_render_an_url_with_priority_0__1.xml
+++ b/tests/__snapshots__/SitemapTest__it_can_render_an_url_with_priority_0__1.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+  <url>
+    <loc>http://localhost/home</loc>
+    <lastmod>2015-12-31T00:00:00+00:00</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
This PR ensures that a URL's priority can be set to 0.

The `<priority>` tag accepts values from 0.0 to 1.0, but this package currently strips out values like `0` and `0.0` (it's possible to work around this by passing something like 0.01, which is rounded down to 0.0 and kept, but that's not ideal).

Omitting the `<priority>` tag is not the same as setting it to 0, because the default priority is 0.5.

Docs: https://www.sitemaps.org/protocol.html#xmlTagDefinitions