### PR TITLE
Add compatibility with spatie/crawler 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "guzzlehttp/guzzle": "^7.2",
         "illuminate/support": "^8.0|^9.0|^10.0",
         "nesbot/carbon": "^2.63",
-        "spatie/crawler": "^7.0",
+        "spatie/crawler": "^7.0|^8.0",
         "spatie/laravel-package-tools": "^1.5",
         "symfony/dom-crawler": "^5.1.14|^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "guzzlehttp/guzzle": "^7.2",
         "illuminate/support": "^8.0|^9.0|^10.0",
         "nesbot/carbon": "^2.63",
-        "spatie/crawler": "^7.0|^8.0",
+        "spatie/crawler": "^8.0",
         "spatie/laravel-package-tools": "^1.5",
         "symfony/dom-crawler": "^5.1.14|^6.0"
     },

--- a/src/Crawler/Observer.php
+++ b/src/Crawler/Observer.php
@@ -59,7 +59,8 @@ class Observer extends CrawlObserver
     public function crawlFailed(
         UriInterface $url,
         RequestException $requestException,
-        ?UriInterface $foundOnUrl = null
+        ?UriInterface $foundOnUrl = null,
+        ?string $linkText = null
     ): void {
     }
 }

--- a/src/Crawler/Observer.php
+++ b/src/Crawler/Observer.php
@@ -43,7 +43,8 @@ class Observer extends CrawlObserver
     public function crawled(
         UriInterface $url,
         ResponseInterface $response,
-        ?UriInterface $foundOnUrl = null
+        ?UriInterface $foundOnUrl = null,
+        ?string $linkText = null
     ): void {
         ($this->hasCrawled)($url, $response);
     }

--- a/src/Crawler/Observer.php
+++ b/src/Crawler/Observer.php
@@ -22,7 +22,7 @@ class Observer extends CrawlObserver
      *
      * @param \Psr\Http\Message\UriInterface $url
      */
-    public function willCrawl(UriInterface $url): void
+    public function willCrawl(UriInterface $url, ?string $linkText): void
     {
     }
 


### PR DESCRIPTION
```
- spatie/laravel-sitemap[6.2.4, ..., 6.3.1] require spatie/crawler ^7.0 -> found spatie/crawler[7.0.0, ..., 7.1.3] but it conflicts with your root composer.json require (^8.0).```