### PR TITLE
Implement addQuery method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 .php_cs.cache
 .phpunit.result.cache
 .php-cs-fixer.cache
+.idea

--- a/README.md
+++ b/README.md
@@ -83,13 +83,14 @@ class Post extends Model implements Sitemapable
 }
 ```
 
-Now you can add a single post model to the sitemap or even a whole collection.
+Now you can add a single post model to the sitemap, a whole collection or a query builder which will automatically chunk and process the items.
 ```php
 use Spatie\Sitemap\Sitemap;
 
 Sitemap::create()
     ->add($post)
-    ->add(Post::all());
+    ->add(Post::all())
+    ->add(Post::query());
 ```
 
 This way you can add all your pages super fast without the need to crawl them all.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ use Spatie\Sitemap\Sitemap;
 Sitemap::create()
     ->add($post)
     ->add(Post::all())
-    ->add(Post::query());
+    ->addQuery(Post::query());
 ```
 
 This way you can add all your pages super fast without the need to crawl them all.

--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -2,8 +2,10 @@
 
 namespace Spatie\Sitemap;
 
+use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Sitemap\Contracts\Sitemapable;
@@ -18,6 +20,17 @@ class Sitemap implements Responsable, Renderable
     public static function create(): static
     {
         return new static();
+    }
+
+    public function addQuery(Builder $query, int $chunkSize = 1000): static
+    {
+        $query->chunk($chunkSize, function(Collection $chunk) {
+            foreach ($chunk as $chunkItem) {
+                $this->add($chunkItem);
+            }
+        });
+
+        return $this;
     }
 
     public function add(string | Url | Sitemapable | iterable $tag): static

--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -2,9 +2,9 @@
 
 namespace Spatie\Sitemap;
 
-use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\Storage;

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Sitemap\Contracts\Sitemapable;
 use Spatie\Sitemap\Sitemap;
@@ -135,6 +136,32 @@ test('multiple urls can be added in one call', function () {
         '/home',
         Url::create('/home'), // filtered
     ]);
+
+    assertMatchesXmlSnapshot($this->sitemap->render());
+});
+
+test('query builder can be added', function() {
+    $this->sitemap
+        ->addQuery(new class implements Builder {
+            public function chunk($count, callable $callback): void
+            {
+                $callback(collect([
+                    new class implements Sitemapable {
+                        public function toSitemapTag(): Url | string | array
+                        {
+                            return Url::create('/model-1');
+                        }
+                    },
+
+                    new class implements Sitemapable {
+                        public function toSitemapTag(): Url | string | array
+                        {
+                            return Url::create('/model-2');
+                        }
+                    }
+                ]));
+            }
+        });
 
     assertMatchesXmlSnapshot($this->sitemap->render());
 });

--- a/tests/__snapshots__/SitemapTest__query_builder_can_be_added__1.xml
+++ b/tests/__snapshots__/SitemapTest__query_builder_can_be_added__1.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+  <url>
+    <loc>http://localhost/model-1</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>http://localhost/model-2</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
This PR adds an `addQuery(Builder, chunkSize)` method to the `Sitemap` object.

Working with models is a great way to optimise sitemap generation process, so this method should help users add models in a more optimised way then adding a whole collection. 

There may be a lot of records we want to add into the sitemap, and we do not want them in memory all at once.

The method assumes that the collection items will be instances of `Sitemapable` interface. "instance of" check is already performed inside the regular `add` method so the `addQuery` does not perform this check.

> [!NOTE]
> The default chunk size is 1000 items