### PR TITLE
Add video tags as separate list

### DIFF
--- a/resources/views/video.blade.php
+++ b/resources/views/video.blade.php
@@ -17,4 +17,7 @@
 @foreach($video->deny as $tag => $value)
     <video:{{$tag}} relationship="deny">{{$value}}</video:{{$tag}}>
 @endforeach
+@foreach($video->tags as $tag)
+    <video:tag>{{ $tag }}</video:tag>
+@endforeach
 </video:video>

--- a/src/Tags/Url.php
+++ b/src/Tags/Url.php
@@ -86,9 +86,9 @@ class Url extends Tag
         return $this;
     }
 
-    public function addVideo(string $thumbnailLoc, string $title, string $description, $contentLoc = null, $playerLoc = null, array $options = [], array $allow = [], array $deny = []): static
+    public function addVideo(string $thumbnailLoc, string $title, string $description, $contentLoc = null, $playerLoc = null, array $options = [], array $allow = [], array $deny = [], array $tags = []): static
     {
-        $this->videos[] = new Video($thumbnailLoc, $title, $description, $contentLoc, $playerLoc, $options, $allow, $deny);
+        $this->videos[] = new Video($thumbnailLoc, $title, $description, $contentLoc, $playerLoc, $options, $allow, $deny, $tags);
 
         return $this;
     }

--- a/src/Tags/Video.php
+++ b/src/Tags/Video.php
@@ -27,7 +27,9 @@ class Video
 
     public array $deny;
 
-    public function __construct(string $thumbnailLoc, string $title, string $description, string $contentLoc = null, string $playerLoc = null, array $options = [], array $allow = [], array $deny = [])
+    public array $tags;
+
+    public function __construct(string $thumbnailLoc, string $title, string $description, string $contentLoc = null, string|array $playerLoc = null, array $options = [], array $allow = [], array $deny = [], array $tags = [])
     {
         if ($contentLoc === null && $playerLoc === null) {
             // https://developers.google.com/search/docs/crawling-indexing/sitemaps/video-sitemaps
@@ -41,7 +43,8 @@ class Video
             ->setPlayerLoc($playerLoc)
             ->setOptions($options)
             ->setAllow($allow)
-            ->setDeny($deny);
+            ->setDeny($deny)
+            ->setTags($tags);
     }
 
     public function setThumbnailLoc(string $thumbnailLoc): self
@@ -96,6 +99,13 @@ class Video
     public function setDeny(array $deny): self
     {
         $this->deny = $deny;
+
+        return $this;
+    }
+
+    public function setTags(array $tags): self
+    {
+        $this->tags = array_slice($tags, 0 , 32); // maximum 32 tags allowed
 
         return $this;
     }

--- a/tests/VideoTest.php
+++ b/tests/VideoTest.php
@@ -20,6 +20,8 @@ test('XML has Video tag', function () {
                                     <video:family_friendly>yes</video:family_friendly>
                                     <video:platform relationship="allow">mobile</video:platform>
                                     <video:restriction relationship="deny">CA</video:restriction>
+                                    <video:tag>tag1</video:tag>
+                                    <video:tag>tag2</video:tag>
                                 </video:video>
                             </url>
                         </urlset>';
@@ -27,10 +29,11 @@ test('XML has Video tag', function () {
     $options = ["live" => "no", "family_friendly" => "yes"];
     $allow = ["platform" => Video::OPTION_PLATFORM_MOBILE];
     $deny = ["restriction" => 'CA'];
+    $tags = ['tag1', 'tag2'];
     $sitemap = Sitemap::create()
         ->add(
             Url::create("https://example.com")
-                ->addVideo("https://example.com/image.jpg", "My Test Title", "My Test Description", "https://example.com/video.mp4", null, $options, $allow, $deny)
+                ->addVideo("https://example.com/image.jpg", "My Test Title", "My Test Description", "https://example.com/video.mp4", null, $options, $allow, $deny, $tags)
         );
 
     $render_output = $sitemap->render();


### PR DESCRIPTION
Sitemap specification allows up to 32 `<video:tag></video:tag>` items, so it makes sense to add it to separate list except of single one in options