### PR TITLE
Removed useless setters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ vendor
 .php_cs.cache
 .phpunit.result.cache
 .php-cs-fixer.cache
+/.idea
+/.phpunit.cache

--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ Sitemap::create()
 
     ->add(Url::create('/home')
         ->setLastModificationDate(Carbon::yesterday())
-        ->setChangeFrequency(Url::CHANGE_FREQUENCY_YEARLY)
-        ->setPriority(0.1))
-
+        
    ->add(...)
 
    ->writeToFile($path);
@@ -40,9 +38,7 @@ SitemapGenerator::create('https://example.com')
    ->getSitemap()
    ->add(Url::create('/extra-page')
         ->setLastModificationDate(Carbon::yesterday())
-        ->setChangeFrequency(Url::CHANGE_FREQUENCY_YEARLY)
-        ->setPriority(0.1))
-
+        
     ->add(...)
 
     ->writeToFile($path);
@@ -85,8 +81,6 @@ class Post extends Model implements Sitemapable
         // Return with fine-grained control:
         return Url::create(route('blog.post.show', $this))
             ->setLastModificationDate(Carbon::create($this->updated_at))
-            ->setChangeFrequency(Url::CHANGE_FREQUENCY_YEARLY)
-            ->setPriority(0.1);
     }
 }
 ```
@@ -209,14 +203,10 @@ The generated sitemap will look similar to this:
     <url>
         <loc>https://example.com</loc>
         <lastmod>2016-01-01T00:00:00+00:00</lastmod>
-        <changefreq>daily</changefreq>
-        <priority>0.8</priority>
     </url>
     <url>
         <loc>https://example.com/page</loc>
         <lastmod>2016-01-01T00:00:00+00:00</lastmod>
-        <changefreq>daily</changefreq>
-        <priority>0.8</priority>
     </url>
 
     ...
@@ -272,8 +262,7 @@ use Spatie\Sitemap\Tags\Url;
 SitemapGenerator::create('https://example.com')
    ->hasCrawled(function (Url $url) {
        if ($url->segment(1) === 'contact') {
-           $url->setPriority(0.9)
-               ->setLastModificationDate(Carbon::create('2016', '1', '1'));
+           $url->setLastModificationDate(Carbon::create('2016', '1', '1'))
        }
 
        return $url;

--- a/src/Tags/Url.php
+++ b/src/Tags/Url.php
@@ -19,10 +19,6 @@ class Url extends Tag
 
     public Carbon $lastModificationDate;
 
-    public string $changeFrequency;
-
-    public float $priority = 0.8;
-
     /** @var \Spatie\Sitemap\Tags\Alternate[] */
     public array $alternates = [];
 
@@ -43,8 +39,6 @@ class Url extends Tag
     public function __construct(string $url)
     {
         $this->url = $url;
-
-        $this->changeFrequency = static::CHANGE_FREQUENCY_DAILY;
     }
 
     public function setUrl(string $url = ''): static
@@ -57,20 +51,6 @@ class Url extends Tag
     public function setLastModificationDate(DateTimeInterface $lastModificationDate): static
     {
         $this->lastModificationDate = Carbon::instance($lastModificationDate);
-
-        return $this;
-    }
-
-    public function setChangeFrequency(string $changeFrequency): static
-    {
-        $this->changeFrequency = $changeFrequency;
-
-        return $this;
-    }
-
-    public function setPriority(float $priority): static
-    {
-        $this->priority = max(0, min($priority, 1));
 
         return $this;
     }

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -8,8 +8,6 @@ test('XML has image', function () {
                         <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
                             <url>
                                 <loc>https://localhost</loc>
-                                <changefreq>daily</changefreq>
-                                <priority>0.8</priority>
                                 <image:image>
                                     <image:loc>https://localhost/favicon.ico</image:loc>
                                     <image:caption>Favicon</image:caption>

--- a/tests/NewsTest.php
+++ b/tests/NewsTest.php
@@ -11,8 +11,6 @@ test('XML has News tag', function () {
                         <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
                             <url>
                                 <loc>https://example.com</loc>
-                                <changefreq>daily</changefreq>
-                                <priority>0.8</priority>
                                 <news:news>
                                     <news:publication>
                                         <news:name>News name</news:name>

--- a/tests/SitemapGeneratorTest.php
+++ b/tests/SitemapGeneratorTest.php
@@ -51,7 +51,7 @@ it('can modify the attributes while generating the sitemap', function () {
     SitemapGenerator::create('http://localhost:4020')
         ->hasCrawled(function (Url $url) {
             if ($url->segment(1) === 'page3') {
-                $url->setPriority(0.6);
+                $url->setLastModificationDate($this->now->subDay());
             }
 
             return $url;

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -91,20 +91,6 @@ it('can render an url with all its set properties', function () {
         ->add(
             Url::create('/home')
                 ->setLastModificationDate($this->now->subDay())
-                ->setChangeFrequency(Url::CHANGE_FREQUENCY_YEARLY)
-                ->setPriority(0.1)
-        );
-
-    assertMatchesXmlSnapshot($this->sitemap->render());
-});
-
-it('can render an url with priority 0', function () {
-    $this->sitemap
-        ->add(
-            Url::create('/home')
-                ->setLastModificationDate($this->now->subDay())
-                ->setChangeFrequency(Url::CHANGE_FREQUENCY_YEARLY)
-                ->setPriority(0.0)
         );
 
     assertMatchesXmlSnapshot($this->sitemap->render());

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -35,24 +35,6 @@ test('last modification date can be set', function () {
         ->toEqual($carbon->toAtomString());
 });
 
-test('priority can be set')
-    ->tap(fn () => $this->url->setPriority(0.1))
-    ->expect(fn () => $this->url->priority)
-    ->toEqual(0.1);
-
-test('priority is clamped')
-    ->tap(fn () => $this->url->setPriority(-0.1))
-    ->expect(fn () => $this->url->priority)
-    ->toEqual(0)
-    ->tap(fn () => $this->url->setPriority(1.1))
-    ->expect(fn () => $this->url->priority)
-    ->toEqual(1);
-
-test('change frequency can be set')
-    ->tap(fn () => $this->url->setChangeFrequency(Url::CHANGE_FREQUENCY_YEARLY))
-    ->expect(fn () => $this->url->changeFrequency)
-    ->toEqual(Url::CHANGE_FREQUENCY_YEARLY);
-
 test('alternate can be added', function () {
     $url = 'defaultUrl';
     $locale = 'en';

--- a/tests/VideoTest.php
+++ b/tests/VideoTest.php
@@ -9,8 +9,6 @@ test('XML has Video tag', function () {
                         <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
                             <url>
                                 <loc>https://example.com</loc>
-                                <changefreq>daily</changefreq>
-                                <priority>0.8</priority>
                                 <video:video>
                                     <video:thumbnail_loc>https://example.com/image.jpg</video:thumbnail_loc>
                                     <video:title>My Test Title</video:title>

--- a/tests/__snapshots__/SitemapGeneratorTest__it_can_generate_a_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapGeneratorTest__it_can_generate_a_sitemap__1.xml
@@ -2,32 +2,20 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
   <url>
     <loc>http://localhost:4020/</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page1</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page2</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page3</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page4</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page5</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapGeneratorTest__it_can_modify_the_attributes_while_generating_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapGeneratorTest__it_can_modify_the_attributes_while_generating_the_sitemap__1.xml
@@ -2,32 +2,21 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
   <url>
     <loc>http://localhost:4020/</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page1</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page2</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page3</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.6</priority>
+    <lastmod>2015-12-31T00:00:00+00:00</lastmod>
   </url>
   <url>
     <loc>http://localhost:4020/page4</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page5</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapGeneratorTest__it_can_use_a_custom_profile__1.xml
+++ b/tests/__snapshots__/SitemapGeneratorTest__it_can_use_a_custom_profile__1.xml
@@ -2,7 +2,5 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
   <url>
     <loc>http://localhost:4020/</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapGeneratorTest__it_will_not_add_the_url_to_the_sitemap_if_hasCrawled()_does_not_return_it__1.xml
+++ b/tests/__snapshots__/SitemapGeneratorTest__it_will_not_add_the_url_to_the_sitemap_if_hasCrawled()_does_not_return_it__1.xml
@@ -2,27 +2,17 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
   <url>
     <loc>http://localhost:4020/</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page1</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page2</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page4</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page5</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapGeneratorTest__it_will_not_crawl_an_url_of_shouldCrawl()_returns_false__1.xml
+++ b/tests/__snapshots__/SitemapGeneratorTest__it_will_not_crawl_an_url_of_shouldCrawl()_returns_false__1.xml
@@ -2,22 +2,14 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
   <url>
     <loc>http://localhost:4020/</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page1</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page2</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost:4020/page4</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__a_url_object_cannot_be_added_twice_to_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapTest__a_url_object_cannot_be_added_twice_to_the_sitemap__1.xml
@@ -2,7 +2,5 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
   <url>
     <loc>http://localhost/home</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__an_url_cannot_be_added_twice_to_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapTest__an_url_cannot_be_added_twice_to_the_sitemap__1.xml
@@ -2,7 +2,5 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
   <url>
     <loc>http://localhost/home</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__an_url_object_can_be_added_to_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapTest__an_url_object_can_be_added_to_the_sitemap__1.xml
@@ -2,7 +2,5 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
   <url>
     <loc>http://localhost/home</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__an_url_string_can_be_added_to_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapTest__an_url_string_can_be_added_to_the_sitemap__1.xml
@@ -2,7 +2,5 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
   <url>
     <loc>http://localhost/home</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__an_url_with_an_alternate_can_be_added_to_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapTest__an_url_with_an_alternate_can_be_added_to_the_sitemap__1.xml
@@ -4,7 +4,5 @@
     <loc>http://localhost/home</loc>
     <xhtml:link rel="alternate" hreflang="nl" href="http://localhost/thuis"/>
     <xhtml:link rel="alternate" hreflang="fr" href="http://localhost/maison"/>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__it_can_render_an_url_with_all_its_set_properties__1.xml
+++ b/tests/__snapshots__/SitemapTest__it_can_render_an_url_with_all_its_set_properties__1.xml
@@ -3,7 +3,5 @@
   <url>
     <loc>http://localhost/home</loc>
     <lastmod>2015-12-31T00:00:00+00:00</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.1</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__it_can_render_an_url_with_priority_0__1.xml
+++ b/tests/__snapshots__/SitemapTest__it_can_render_an_url_with_priority_0__1.xml
@@ -3,7 +3,5 @@
   <url>
     <loc>http://localhost/home</loc>
     <lastmod>2015-12-31T00:00:00+00:00</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.0</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__multiple_urls_can_be_added_in_one_call__1.xml
+++ b/tests/__snapshots__/SitemapTest__multiple_urls_can_be_added_in_one_call__1.xml
@@ -2,12 +2,8 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
   <url>
     <loc>http://localhost</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost/home</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__multiple_urls_can_be_added_to_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapTest__multiple_urls_can_be_added_to_the_sitemap__1.xml
@@ -2,12 +2,8 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
   <url>
     <loc>http://localhost/home</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost/contact</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__sitemapable_object_can_be_added__1.xml
+++ b/tests/__snapshots__/SitemapTest__sitemapable_object_can_be_added__1.xml
@@ -2,22 +2,14 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
   <url>
     <loc>http://localhost</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost/home</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost/blog/post-1</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost/blog/post-2</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
 </urlset>

--- a/tests/__snapshots__/SitemapTest__sitemapable_objects_can_be_added__1.xml
+++ b/tests/__snapshots__/SitemapTest__sitemapable_objects_can_be_added__1.xml
@@ -2,17 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
   <url>
     <loc>http://localhost/blog/post-1</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost/blog/post-2</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>http://localhost/blog/post-3</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
   </url>
 </urlset>


### PR DESCRIPTION
Hi! I recently started using this library and found that the priority and changefreq parameters are deprecated. In this regard, I decided to basically remove them from the code.
To be honest, I don't think it would be right to delete these parameters, because there is not only the Google search engine, perhaps these parameters are still relevant in other search engines.  I would be happy if you didn't accept my deletion request and rolled back this one: https://github.com/spatie/laravel-sitemap/pull/545 
Thank you.