### PR TITLE
Make BrowserShot Optional in SitemapGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ composer require spatie/laravel-sitemap
 
 The package will automatically register itself.
 
+If you intend to use the crawler to generate your sitemap, you also need to install the [Spatie's Crawler](https://github.com/spatie/crawler) package:
+
+``` bash
+composer require spatie/crawler
+```
+
 If you want to update your sitemap automatically and frequently you need to perform [some extra steps](https://github.com/spatie/laravel-sitemap#generating-the-sitemap-frequently).
 
 ## Configuration

--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,7 @@
         }
     },
     "suggest": {
-        "spatie/crawler": "Required to use the crawler feature",
-        "symfony/dom-crawler": "Required to use the crawler feature"
+        "spatie/crawler": "Required to use the crawler feature"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,7 @@
         "guzzlehttp/guzzle": "^7.8",
         "illuminate/support": "^10.0|^11.0",
         "nesbot/carbon": "^2.71|^3.0",
-        "spatie/crawler": "^8.0.1",
-        "spatie/laravel-package-tools": "^1.16.1",
-        "symfony/dom-crawler": "^6.3.4|^7.0"
+        "spatie/laravel-package-tools": "^1.16.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.6.6",
@@ -44,6 +42,10 @@
                 "Spatie\\Sitemap\\SitemapServiceProvider"
             ]
         }
+    },
+    "suggest": {
+        "spatie/crawler": "Required to use the crawler feature",
+        "symfony/dom-crawler": "Required to use the crawler feature"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## **Summary of the Change**  
This pull request proposes making **BrowserShot** and the **Crawler** functionality optional in the **SitemapGenerator** package. The current implementation forces these dependencies even for users who don’t require dynamic crawling, introducing security risks and compatibility challenges.

Given the recent **security issue** in **BrowserShot**, along with its **PHP version requirements**, and the additional unnecessary dependencies, this change aims to improve flexibility and reduce overhead for users of the package.

## **Why This Change is Necessary**  

### 1. **Security Concern**  
The **BrowserShot** package had a **security issue** that was patched in **version 5**. However, the patched version requires **PHP 8.2**. Many applications, including ours, are still running on **PHP 8.1**, leaving them unable to use the patched version and exposed to vulnerabilities in **BrowserShot v3**.

### 2. **Unnecessary Dependencies**  
Currently, **Spatie Laravel Sitemap** pulls in several dependencies that are only required for the **Crawler** feature. For users who generate sitemaps directly (without crawling), these dependencies add unnecessary overhead, increasing maintenance complexity and potential attack surfaces.

### 3. **Symfony DomCrawler Note**  
We noticed that **`symfony/dom-crawler`** is explicitly required in the **`composer.json`** of **`spatie/laravel-sitemap`**, but it appears to be **unnecessary** as it is already required by **`spatie/crawler`**.

👉 **Reference:** [spatie/crawler `composer.json`](https://github.com/spatie/crawler/blob/main/composer.json#L26)

### 4. **Our Use Case**  
In our projects, we generate sitemaps directly from routes and database queries. We do not use the crawling functionality, yet we are forced to install these dependencies, which are never actually used in our application.

## **Removed Dependencies**  
By making **BrowserShot** and **Crawler** optional, the following packages will no longer be required:

| **Package**               |
|---------------------------|
| `masterminds/html5`        |
| `nicmart/tree`             |
| `spatie/browsershot`       |
| `spatie/crawler`           |
| `spatie/robots-txt`        |
| `spatie/temporary-directory` |
| `symfony/dom-crawler`      |

## **Benefits of This Change**  

1. **Reduced Security Risk**  
   Users who don’t require dynamic crawling won’t be exposed to potential vulnerabilities in these packages if any arise in the future.
   
2. **Reduced Overhead**  
   Removing unnecessary dependencies results in a lighter application footprint, faster builds, and less complexity.

3. **Increased Flexibility**  
   Users can choose to install **BrowserShot** and **Crawler** only if their use case requires it.

## **Proposed Change**  
As the **SitemapGenerator** class is already conditionally using **BrowserShot** only when the package is configured to use the **Crawler**, we propose to:

- Move the dependencies from the required section to the suggest on the `composer.json` file.
- Update the package documentation to clarify that these features are optional and provide guidance on how to enable them if needed.
- Review the **`symfony/dom-crawler`** dependency to ensure it is truly necessary in **`spatie/laravel-sitemap`**.

## **Closing Thoughts**  
We highly value the contributions of **Spatie** to the Laravel community. This proposed change aims to improve the **Laravel Sitemap** package by making it more flexible and secure while reducing unnecessary dependencies for users who don’t need the **Crawler** functionality.

We appreciate your consideration of this pull request and look forward to any feedback. Thank you for your continued efforts to enhance the Laravel ecosystem!