### PR TITLE
remove deprecated tgas from image and video blade

### DIFF
--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -2,15 +2,6 @@
 @if (! empty($image->url))
     <image:loc>{{ url($image->url) }}</image:loc>
 @endif
-@if (! empty($image->caption))
-    <image:caption>{{ $image->caption }}</image:caption>
-@endif
-@if (! empty($image->geo_location))
-    <image:geo_location>{{ $image->geo_location }}</image:geo_location>
-@endif
-@if (! empty($image->title))
-    <image:title>{{ $image->title }}</image:title>
-@endif
 @if (! empty($image->license))
     <image:license>{{ $image->license }}</image:license>
 @endif

--- a/resources/views/video.blade.php
+++ b/resources/views/video.blade.php
@@ -5,9 +5,6 @@
 @if ($video->contentLoc)
     <video:content_loc>{{ $video->contentLoc }}</video:content_loc>
 @endif
-@if ($video->playerLoc)
-    <video:player_loc>{{ $video->playerLoc }}</video:player_loc>
-@endif
 @foreach($video->options as $tag => $value)
     <video:{{$tag}}>{{$value}}</video:{{$tag}}>
 @endforeach

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -10,7 +10,6 @@ test('XML has image', function () {
                                 <loc>https://localhost</loc>
                                 <image:image>
                                     <image:loc>https://localhost/favicon.ico</image:loc>
-                                    <image:caption>Favicon</image:caption>
                                 </image:image>
                             </url>
                         </urlset>';


### PR DESCRIPTION
 remove  the following Deprecated  tags and attributes 

### image 

- caption
- geo_location
- title

### Video 

-  player_loc

source and more information 
[ some sitemap extension tags are going away](https://developers.google.com/search/blog/2022/05/spring-cleaning-sitemap-extensions)