### PR TITLE
Added addCanonical option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,11 @@
 {
     "name": "3xpo/laravel-sitemap",
-    "description": "Create and generate sitemaps with ease",
+    "description": "Added canonical link options",
     "keywords": [
         "spatie",
         "laravel-sitemap"
     ],
+    "version": "1.0.0",
     "homepage": "https://github.com/spatie/laravel-sitemap",
     "license": "MIT",
     "authors": [
@@ -55,7 +56,7 @@
             "Spatie\\Sitemap\\Test\\": "tests"
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "scripts": {
         "test": "vendor/bin/pest"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "spatie/laravel-sitemap",
+    "name": "3xpo/laravel-sitemap",
     "description": "Create and generate sitemaps with ease",
     "keywords": [
         "spatie",

--- a/resources/views/url.blade.php
+++ b/resources/views/url.blade.php
@@ -2,6 +2,11 @@
     @if (! empty($tag->url))
     <loc>{{ url($tag->url) }}</loc>
     @endif
+@if (count($tag->canonicals))
+@foreach ($tag->canonicals as $canonical)
+    <xhtml:link rel="canonical" href="{{ url($canonical->url) }}" />
+    @endforeach
+@endif
 @if (count($tag->alternates))
 @foreach ($tag->alternates as $alternate)
     <xhtml:link rel="alternate" hreflang="{{ $alternate->locale }}" href="{{ url($alternate->url) }}" />

--- a/src/Tags/Canonical.php
+++ b/src/Tags/Canonical.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\Sitemap\Tags;
+
+class Canonical
+{
+    public string $url;
+
+    public static function create(string $url): static
+    {
+        return new static($url);
+    }
+
+    public function __construct(string $url)
+    {
+        $this->setUrl($url);
+
+    }
+
+    public function setUrl(string $url = ''): static
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+}

--- a/src/Tags/Url.php
+++ b/src/Tags/Url.php
@@ -26,6 +26,9 @@ class Url extends Tag
     /** @var \Spatie\Sitemap\Tags\Alternate[] */
     public array $alternates = [];
 
+    /** @var \Spatie\Sitemap\Tags\Canonical[] */
+    public array $canonicals = [];
+
     /** @var \Spatie\Sitemap\Tags\Image[] */
     public array $images = [];
 
@@ -78,6 +81,13 @@ class Url extends Tag
     public function addAlternate(string $url, string $locale = ''): static
     {
         $this->alternates[] = new Alternate($url, $locale);
+
+        return $this;
+    }
+
+    public function addCanonical(string $url): static
+    {
+        $this->canonicals[] = new Canonical($url);
 
         return $this;
     }


### PR DESCRIPTION
Added an addCanonical option, which is recommended when creating sitemaps in multiple language variations.
Example:
<url>
    <loc>https://domain/it/terms-of-use</loc>
    **<xhtml:link rel="canonical" href="https://domain/it/terms-of-use" />**
    <xhtml:link rel="alternate" hreflang="en" href="https://domain/terms-of-use" />
    <xhtml:link rel="alternate" hreflang="zh" href="https://domain/zh/terms-of-use" />
    <xhtml:link rel="alternate" hreflang="hi" href="https://domain/hi/terms-of-use" />