### PR TITLE
Make `$response` param explicitly nullable 

### DIFF
--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -45,7 +45,7 @@ class SitemapGenerator
 
         $this->sitemaps = new Collection([new Sitemap]);
 
-        $this->hasCrawled = fn (Url $url, ResponseInterface $response = null) => $url;
+        $this->hasCrawled = fn (Url $url, ?ResponseInterface $response = null) => $url;
     }
 
     public function configureCrawler(Closure $closure): static
@@ -174,7 +174,7 @@ class SitemapGenerator
 
     protected function getCrawlObserver(): Observer
     {
-        $performAfterUrlHasBeenCrawled = function (UriInterface $crawlerUrl, ResponseInterface $response = null) {
+        $performAfterUrlHasBeenCrawled = function (UriInterface $crawlerUrl, ?ResponseInterface $response = null) {
             $sitemapUrl = ($this->hasCrawled)(Url::create((string) $crawlerUrl), $response);
 
             if ($this->shouldStartNewSitemapFile()) {


### PR DESCRIPTION
Hey 👋 

Whilst upgrading my application to PHP8.4, I was getting these deprecation warnings when running my test suite:

> {closure:Spatie\Sitemap\SitemapGenerator::__construct():48}(): Implicitly marking parameter $response as nullable is deprecated, the explicit nullable type must be used instead

and

> {closure:Spatie\Sitemap\SitemapGenerator::__construct():177}(): Implicitly marking parameter $response as nullable is deprecated, the explicit nullable type must be used instead

This PR ensures that the `$reponse` param is explicitly nullable and therefore no longer shows the deprecation warning. 

Thanks!
