### PR TITLE
Skip empty URL string returned from `toSitemapTag()`

### DIFF
--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -34,6 +34,10 @@ class Sitemap implements Responsable, Renderable
             return $this;
         }
 
+        if (is_string($tag) && trim($tag) === '') {
+            return $this;
+        }
+
         if (is_string($tag)) {
             $tag = Url::create($tag);
         }

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -55,6 +55,13 @@ test('an url string can be added to the sitemap', function () {
     assertMatchesXmlSnapshot($this->sitemap->render());
 });
 
+test('an empty string cannot be added to the sitemap', function () {
+    $this->sitemap->add('');
+    $this->sitemap->add('  ');
+
+    assertMatchesXmlSnapshot($this->sitemap->render());
+});
+
 test('an url cannot be added twice to the sitemap', function () {
     $this->sitemap->add('/home');
     $this->sitemap->add('/home');
@@ -158,6 +165,24 @@ test('multiple urls can be added in one call', function () {
         '/home',
         Url::create('/home'), // filtered
     ]);
+
+    assertMatchesXmlSnapshot($this->sitemap->render());
+});
+
+test('sitemapable object with empty string cannot be added', function () {
+    $this->sitemap
+        ->add(new class implements Sitemapable {
+            public function toSitemapTag(): Url | string | array
+            {
+                return '';
+            }
+        })
+        ->add(new class implements Sitemapable {
+            public function toSitemapTag(): Url | string | array
+            {
+                return '  ';
+            }
+        });
 
     assertMatchesXmlSnapshot($this->sitemap->render());
 });

--- a/tests/__snapshots__/SitemapTest__an_empty_string_cannot_be_added_to_the_sitemap__1.xml
+++ b/tests/__snapshots__/SitemapTest__an_empty_string_cannot_be_added_to_the_sitemap__1.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+</urlset>

--- a/tests/__snapshots__/SitemapTest__sitemapable_object_with_empty_string_cannot_be_added__1.xml
+++ b/tests/__snapshots__/SitemapTest__sitemapable_object_with_empty_string_cannot_be_added__1.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+</urlset>


### PR DESCRIPTION
Google does not support empty URL in the sitemap. 

To not introduce a breaking change in the method's `toSitemapTag()` signature (`null`), we can skip empty strings to not generate invalid XML file.